### PR TITLE
Report values using BSON data types

### DIFF
--- a/lib/oboe/api/logging.rb
+++ b/lib/oboe/api/logging.rb
@@ -191,7 +191,7 @@ module Oboe
                 value = v
               end
 
-              event.addInfo(k.to_s, value) if valid_key? k
+              event.addInfo(k.to_s, value)
             end
           end if !opts.nil? && opts.any?
 

--- a/lib/oboe/api/logging.rb
+++ b/lib/oboe/api/logging.rb
@@ -181,7 +181,18 @@ module Oboe
           Oboe.layer = nil   if label == 'exit'
 
           opts.each do |k, v|
-            event.addInfo(k.to_s, v.to_s) if valid_key? k
+            if valid_key? k
+              if [Class, Module, Symbol, Array, Hash,
+                  TrueClass, FalseClass].include?(v.class)
+                value = v.to_s
+              elsif v.class == Set
+                value = v.to_a.to_s
+              else
+                value = v
+              end
+
+              event.addInfo(k.to_s, value) if valid_key? k
+            end
           end if !opts.nil? && opts.any?
 
           Oboe::Reporter.sendReport(event) if Oboe.loaded

--- a/test/frameworks/grape_test.rb
+++ b/test/frameworks/grape_test.rb
@@ -79,7 +79,7 @@ if RUBY_VERSION >= '1.9.3'
       traces[3]['ErrorMsg'].must_equal "This is a error with 'error'!"
       traces[4]['Layer'].must_equal "rack"
       traces[4]['Label'].must_equal "exit"
-      traces[4]['Status'].must_equal "500"
+      traces[4]['Status'].must_equal 500
     end
   end
 end

--- a/test/instrumentation/cassandra_test.rb
+++ b/test/instrumentation/cassandra_test.rb
@@ -76,8 +76,8 @@ unless defined?(JRUBY_VERSION)
       traces[1]['Op'].must_equal "insert"
       traces[1]['Cf'].must_equal "Users"
       traces[1]['Key'].must_equal "\"5\""
-      traces[1]['Consistency'].must_equal "1"
-      traces[1]['Ttl'].must_equal "600"
+      traces[1]['Consistency'].must_equal 1
+      traces[1]['Ttl'].must_equal 600
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:cassandra][:collect_backtraces]
       validate_event_keys(traces[2], @exit_kvs)
     end
@@ -116,7 +116,7 @@ unless defined?(JRUBY_VERSION)
       traces[1]['Op'].must_equal "count_columns"
       traces[1]['Cf'].must_equal "Statuses"
       traces[1]['Key'].must_equal "\"12\""
-      traces[1]['Count'].must_equal "50"
+      traces[1]['Count'].must_equal 50
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:cassandra][:collect_backtraces]
       validate_event_keys(traces[2], @exit_kvs)
     end

--- a/test/instrumentation/faraday_test.rb
+++ b/test/instrumentation/faraday_test.rb
@@ -38,7 +38,7 @@ describe Oboe::Inst::FaradayConnection do
     traces[1].key?('Backtrace').must_equal Oboe::Config[:faraday][:collect_backtraces]
 
     traces[3]['Layer'].must_equal 'net-http'
-    traces[3]['IsService'].must_equal '1'
+    traces[3]['IsService'].must_equal 1
     traces[3]['RemoteProtocol'].must_equal 'HTTP'
     traces[3]['RemoteHost'].must_equal 'www.gameface.in'
     traces[3]['ServiceArg'].must_equal '/games?q=1'
@@ -69,7 +69,7 @@ describe Oboe::Inst::FaradayConnection do
     traces[1].key?('Backtrace').must_equal Oboe::Config[:faraday][:collect_backtraces]
 
     traces[3]['Layer'].must_equal 'net-http'
-    traces[3]['IsService'].must_equal '1'
+    traces[3]['IsService'].must_equal 1
     traces[3]['RemoteProtocol'].must_equal 'HTTP'
     traces[3]['RemoteHost'].must_equal 'www.curlmyip.com'
     traces[3]['ServiceArg'].must_equal '/?q=ruby_test_suite'
@@ -100,7 +100,7 @@ describe Oboe::Inst::FaradayConnection do
     traces[1].key?('Backtrace').must_equal Oboe::Config[:faraday][:collect_backtraces]
 
     traces[3]['Layer'].must_equal 'net-http'
-    traces[3]['IsService'].must_equal '1'
+    traces[3]['IsService'].must_equal 1
     traces[3]['RemoteProtocol'].must_equal 'HTTP'
     traces[3]['RemoteHost'].must_equal 'www.curlmyip.com'
     traces[3]['ServiceArg'].must_equal '/?a=1'
@@ -133,7 +133,7 @@ describe Oboe::Inst::FaradayConnection do
     traces[1]['Layer'].must_equal 'faraday'
     traces[1].key?('Backtrace').must_equal Oboe::Config[:faraday][:collect_backtraces]
 
-    traces[2]['IsService'].must_equal '1'
+    traces[2]['IsService'].must_equal 1
     traces[2]['RemoteProtocol'].must_equal 'HTTP'
     traces[2]['RemoteHost'].must_equal 'www.curlmyip.com'
     traces[2]['ServiceArg'].must_equal '/?q=1'
@@ -141,7 +141,7 @@ describe Oboe::Inst::FaradayConnection do
 
     traces[2]['Layer'].must_equal 'faraday'
     traces[2]['Label'].must_equal 'info'
-    traces[2]['HTTPStatus'].must_equal '200'
+    traces[2]['HTTPStatus'].must_equal 200
 
     traces[3]['Layer'].must_equal 'faraday'
     traces[3]['Label'].must_equal 'exit'

--- a/test/instrumentation/http_test.rb
+++ b/test/instrumentation/http_test.rb
@@ -37,7 +37,7 @@ describe Oboe::Inst do
     validate_outer_layers(traces, 'net-http_test')
 
     traces[1]['Layer'].must_equal 'net-http'
-    traces[2]['IsService'].must_equal "1"
+    traces[2]['IsService'].must_equal 1
     traces[2]['RemoteProtocol'].must_equal "HTTP"
     traces[2]['RemoteHost'].must_equal "www.gameface.in"
     traces[2]['ServiceArg'].must_equal "/games?q=1"
@@ -59,7 +59,7 @@ describe Oboe::Inst do
     validate_outer_layers(traces, 'net-http_test')
 
     traces[1]['Layer'].must_equal 'net-http'
-    traces[2]['IsService'].must_equal "1"
+    traces[2]['IsService'].must_equal 1
     traces[2]['RemoteProtocol'].must_equal "HTTP"
     traces[2]['RemoteHost'].must_equal "www.curlmyip.com"
     traces[2]['ServiceArg'].must_equal "/?q=1"

--- a/test/instrumentation/memcache_test.rb
+++ b/test/instrumentation/memcache_test.rb
@@ -101,7 +101,7 @@ describe Oboe::API::Memcache do
     traces[1]['KVOp'].must_equal "get_multi"
 
     validate_event_keys(traces[2], @info_kvs)
-    traces[2]['KVKeyCount'].must_equal "6"
+    traces[2]['KVKeyCount'].must_equal 6
     traces[2].has_key?('KVHitCount').must_equal true
     traces[2].has_key?('Backtrace').must_equal Oboe::Config[:memcache][:collect_backtraces]
 

--- a/test/instrumentation/memcached_test.rb
+++ b/test/instrumentation/memcached_test.rb
@@ -89,7 +89,7 @@ if RUBY_VERSION < '2.0' and not defined?(JRUBY_VERSION)
 
       traces[1]['KVOp'].must_equal "get_multi"
 
-      traces[2]['KVKeyCount'].must_equal "6"
+      traces[2]['KVKeyCount'].must_equal 6
       traces[2].has_key?('KVHitCount').must_equal true
     end
 

--- a/test/instrumentation/moped_test.rb
+++ b/test/instrumentation/moped_test.rb
@@ -18,7 +18,7 @@ if RUBY_VERSION >= '1.9.3'
         'Flavor' => 'mongodb',
         'Database' => 'moped_test',
         'RemoteHost' => '127.0.0.1',
-        'RemotePort' => '27017' }
+        'RemotePort' => 27017 }
 
       @exit_kvs = { 'Layer' => 'mongo', 'Label' => 'exit' }
       @collect_backtraces = Oboe::Config[:moped][:collect_backtraces]

--- a/test/instrumentation/rack_test.rb
+++ b/test/instrumentation/rack_test.rb
@@ -34,9 +34,9 @@ class RackTestApp < Minitest::Test
 
     kvs.clear
     kvs["Label"] = "exit"
-    kvs["Status"] = "200"
+    kvs["Status"] = 200
     kvs["HTTP-Host"] = "example.org"
-    kvs["Port"] = "80"
+    kvs["Port"] = 80
     kvs["Proto"] = "http"
     kvs["URL"] = "/lobster"
     kvs["Method"] = "GET"

--- a/test/instrumentation/redis_hashes_test.rb
+++ b/test/instrumentation/redis_hashes_test.rb
@@ -90,9 +90,9 @@ describe Oboe::Inst::Redis, :hashes do
     traces.count.must_equal 6
     traces[2]['KVOp'].must_equal "hget"
     traces[2]['KVKey'].must_equal "whale"
-    traces[2]['KVHit'].must_equal "1"
+    traces[2]['KVHit'].must_equal 1
     traces[2]['field'].must_equal "color"
-    traces[4]['KVHit'].must_equal "0"
+    traces[4]['KVHit'].must_equal 0
   end
 
   it "should trace hgetall" do
@@ -124,7 +124,7 @@ describe Oboe::Inst::Redis, :hashes do
     traces[2]['KVOp'].must_equal "hincrby"
     traces[2]['KVKey'].must_equal "whale"
     traces[2]['field'].must_equal "age"
-    traces[2]['increment'].must_equal "1"
+    traces[2]['increment'].must_equal 1
   end
 
   it "should trace hincrbyfloat" do
@@ -141,7 +141,7 @@ describe Oboe::Inst::Redis, :hashes do
     traces[2]['KVOp'].must_equal "hincrbyfloat"
     traces[2]['KVKey'].must_equal "whale"
     traces[2]['field'].must_equal "age"
-    traces[2]['increment'].must_equal "1.3"
+    traces[2]['increment'].must_equal 1.3
   end
 
   it "should trace hkeys" do
@@ -189,8 +189,8 @@ describe Oboe::Inst::Redis, :hashes do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "hmget"
     traces[2]['KVKey'].must_equal "whale"
-    traces[2]['KVKeyCount'].must_equal "4"
-    traces[2]['KVHitCount'].must_equal "2"
+    traces[2]['KVKeyCount'].must_equal 4
+    traces[2]['KVHitCount'].must_equal 2
   end
 
   it "should trace hmset" do

--- a/test/instrumentation/redis_keys_test.rb
+++ b/test/instrumentation/redis_keys_test.rb
@@ -130,7 +130,7 @@ describe Oboe::Inst::Redis, :keys do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "move"
     traces[2]['KVKey'].must_equal "piano"
-    traces[2]['db'].must_equal "1"
+    traces[2]['db'].must_equal 1
   end
 
   it "should trace persist" do
@@ -163,7 +163,7 @@ describe Oboe::Inst::Redis, :keys do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "pexpire"
     traces[2]['KVKey'].must_equal "sand"
-    traces[2]['milliseconds'].must_equal "8000"
+    traces[2]['milliseconds'].must_equal 8000
   end
 
   it "should trace pexpireat" do
@@ -181,7 +181,7 @@ describe Oboe::Inst::Redis, :keys do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "pexpireat"
     traces[2]['KVKey'].must_equal "sand"
-    traces[2]['milliseconds'].must_equal "8000"
+    traces[2]['milliseconds'].must_equal 8000
   end
 
   it "should trace pttl" do
@@ -252,7 +252,7 @@ describe Oboe::Inst::Redis, :keys do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "restore"
     traces[2]['KVKey'].must_equal "blue"
-    traces[2]['ttl'].must_equal "0"
+    traces[2]['ttl'].must_equal 0
   end
 
   it "should trace sort" do

--- a/test/instrumentation/redis_lists_test.rb
+++ b/test/instrumentation/redis_lists_test.rb
@@ -85,7 +85,7 @@ describe Oboe::Inst::Redis, :lists do
     traces = get_all_traces
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "lindex"
-    traces[2]['index'].must_equal "1"
+    traces[2]['index'].must_equal 1
   end
 
   it "should trace linsert" do
@@ -182,8 +182,8 @@ describe Oboe::Inst::Redis, :lists do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "lrange"
     traces[2]['KVKey'].must_equal "protein types"
-    traces[2]['start'].must_equal "2"
-    traces[2]['stop'].must_equal "4"
+    traces[2]['start'].must_equal 2
+    traces[2]['stop'].must_equal 4
   end
 
   it "should trace lrem" do

--- a/test/instrumentation/redis_misc_test.rb
+++ b/test/instrumentation/redis_misc_test.rb
@@ -46,7 +46,7 @@ describe Oboe::Inst::Redis, :misc do
     traces = get_all_traces
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "select"
-    traces[2]['db'].must_equal "2"
+    traces[2]['db'].must_equal 2
   end
 
   it "should trace pipelined operations" do
@@ -66,7 +66,7 @@ describe Oboe::Inst::Redis, :misc do
 
     traces = get_all_traces
     traces.count.must_equal 4
-    traces[2]['KVOpCount'].must_equal "6"
+    traces[2]['KVOpCount'].must_equal 6
     traces[2]['KVOps'].must_equal "zadd, zadd, zadd, lpush, lpush, lpush"
   end
 
@@ -87,7 +87,7 @@ describe Oboe::Inst::Redis, :misc do
 
     traces = get_all_traces
     traces.count.must_equal 4
-    traces[2]['KVOpCount'].must_equal "8"
+    traces[2]['KVOpCount'].must_equal 8
     traces[2]['KVOps'].must_equal "multi, zadd, zadd, zadd, lpush, lpush, lpush, exec"
   end
 

--- a/test/instrumentation/redis_sortedsets_test.rb
+++ b/test/instrumentation/redis_sortedsets_test.rb
@@ -206,8 +206,8 @@ describe Oboe::Inst::Redis, :sortedsets do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "zremrangebyrank"
     traces[2]['KVKey'].must_equal "sauce"
-    traces[2]['start'].must_equal "-5"
-    traces[2]['stop'].must_equal "-1"
+    traces[2]['start'].must_equal -5
+    traces[2]['stop'].must_equal -1
   end
 
   it "should trace zremrangebyscore" do
@@ -246,8 +246,8 @@ describe Oboe::Inst::Redis, :sortedsets do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "zrevrange"
     traces[2]['KVKey'].must_equal "sauce"
-    traces[2]['start'].must_equal "0"
-    traces[2]['stop'].must_equal "-1"
+    traces[2]['start'].must_equal 0
+    traces[2]['stop'].must_equal -1
   end
 
   it "should trace zrevrangebyscore" do

--- a/test/instrumentation/redis_strings_test.rb
+++ b/test/instrumentation/redis_strings_test.rb
@@ -46,8 +46,8 @@ describe Oboe::Inst::Redis, :strings do
     traces = get_all_traces
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "bitcount"
-    traces[2]['start'].must_equal "0"
-    traces[2]['stop'].must_equal "-1"
+    traces[2]['start'].must_equal 0
+    traces[2]['stop'].must_equal -1
   end
 
   it "should trace bitop (>=2.6)" do
@@ -89,7 +89,7 @@ describe Oboe::Inst::Redis, :strings do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "decrby"
     traces[2]['KVKey'].must_equal "decr"
-    traces[2]['decrement'].must_equal "1"
+    traces[2]['decrement'].must_equal 1
   end
 
   it "should trace get" do
@@ -120,7 +120,7 @@ describe Oboe::Inst::Redis, :strings do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "getbit"
     traces[2]['KVKey'].must_equal "diwore"
-    traces[2]['offset'].must_equal "3"
+    traces[2]['offset'].must_equal 3
   end
 
   it "should trace getrange" do
@@ -134,8 +134,8 @@ describe Oboe::Inst::Redis, :strings do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "getrange"
     traces[2]['KVKey'].must_equal "yourkey"
-    traces[2]['start'].must_equal "0"
-    traces[2]['end'].must_equal "3"
+    traces[2]['start'].must_equal 0
+    traces[2]['end'].must_equal 3
   end
 
   it "should trace getset" do
@@ -176,7 +176,7 @@ describe Oboe::Inst::Redis, :strings do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "incrby"
     traces[2]['KVKey'].must_equal "incr"
-    traces[2]['increment'].must_equal "1"
+    traces[2]['increment'].must_equal 1
   end
 
   it "should trace incrbyfloat" do
@@ -192,7 +192,7 @@ describe Oboe::Inst::Redis, :strings do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "incrbyfloat"
     traces[2]['KVKey'].must_equal "incrfloat"
-    traces[2]['increment'].must_equal "1.01"
+    traces[2]['increment'].must_equal 1.01
   end
 
   it "should trace mget" do
@@ -208,11 +208,11 @@ describe Oboe::Inst::Redis, :strings do
     traces = get_all_traces
     traces.count.must_equal 6
     traces[2]['KVOp'].must_equal "mget"
-    traces[2]['KVKeyCount'].must_equal "3"
-    traces[2]['KVHitCount'].must_equal "2"
+    traces[2]['KVKeyCount'].must_equal 3
+    traces[2]['KVHitCount'].must_equal 2
     traces[4]['KVOp'].must_equal "mget"
-    traces[4]['KVKeyCount'].must_equal "1"
-    traces[4]['KVHitCount'].must_equal "1"
+    traces[4]['KVKeyCount'].must_equal 1
+    traces[4]['KVHitCount'].must_equal 1
   end
 
   it "should trace mset" do
@@ -224,9 +224,9 @@ describe Oboe::Inst::Redis, :strings do
     traces = get_all_traces
     traces.count.must_equal 6
     traces[2]['KVOp'].must_equal "mset"
-    traces[2]['KVKeyCount'].must_equal "3"
+    traces[2]['KVKeyCount'].must_equal 3
     traces[4]['KVOp'].must_equal "mset"
-    traces[4]['KVKeyCount'].must_equal "1"
+    traces[4]['KVKeyCount'].must_equal 1
   end
 
   it "should trace msetnx" do
@@ -249,7 +249,7 @@ describe Oboe::Inst::Redis, :strings do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "psetex"
     traces[2]['KVKey'].must_equal "one"
-    traces[2]['ttl'].must_equal "60"
+    traces[2]['ttl'].must_equal 60
   end
 
   it "should trace basic set" do
@@ -274,7 +274,7 @@ describe Oboe::Inst::Redis, :strings do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "setbit"
     traces[2]['KVKey'].must_equal "yourkey"
-    traces[2]['offset'].must_equal "3"
+    traces[2]['offset'].must_equal 3
   end
 
   it "should trace setex" do
@@ -286,7 +286,7 @@ describe Oboe::Inst::Redis, :strings do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "setex"
     traces[2]['KVKey'].must_equal "one"
-    traces[2]['ttl'].must_equal "60"
+    traces[2]['ttl'].must_equal 60
   end
 
   it "should trace setnx" do
@@ -313,7 +313,7 @@ describe Oboe::Inst::Redis, :strings do
     traces.count.must_equal 4
     traces[2]['KVOp'].must_equal "setrange"
     traces[2]['KVKey'].must_equal "yourkey"
-    traces[2]['offset'].must_equal "2"
+    traces[2]['offset'].must_equal 2
   end
 
   it "should trace strlen" do

--- a/test/instrumentation/sequel_mysql2_test.rb
+++ b/test/instrumentation/sequel_mysql2_test.rb
@@ -26,7 +26,7 @@ unless defined?(JRUBY_VERSION)
         'Label' => 'entry',
         'Database' => 'travis_ci_test',
         'RemoteHost' => '127.0.0.1',
-        'RemotePort' => '3306' }
+        'RemotePort' => 3306 }
 
       @exit_kvs = { 'Layer' => 'sequel', 'Label' => 'exit' }
       @collect_backtraces = Oboe::Config[:sequel][:collect_backtraces]

--- a/test/instrumentation/sequel_mysql2_test.rb
+++ b/test/instrumentation/sequel_mysql2_test.rb
@@ -122,11 +122,9 @@ unless defined?(JRUBY_VERSION)
       validate_outer_layers(traces, 'sequel_test')
 
       validate_event_keys(traces[1], @entry_kvs)
-      if RUBY_VERSION < "1.9"
-        traces[1]['Query'].must_equal "INSERT INTO `items` (`price`, `name`) VALUES (2.51446138335246, 'abc')"
-      else
-        traces[1]['Query'].must_equal "INSERT INTO `items` (`name`, `price`) VALUES ('abc', 2.514461383352462)"
-      end
+
+      traces[1]['Query'].must_equal "INSERT INTO `items` (`price`, `name`) VALUES (2.51446138335246, 'abc')" ||
+                                    "INSERT INTO `items` (`name`, `price`) VALUES ('abc', 2.514461383352462)"
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]
       traces[2]['Layer'].must_equal "sequel"
       traces[2]['Label'].must_equal "exit"
@@ -149,11 +147,9 @@ unless defined?(JRUBY_VERSION)
       validate_outer_layers(traces, 'sequel_test')
 
       validate_event_keys(traces[1], @entry_kvs)
-      if RUBY_VERSION < "1.9"
-        traces[1]['Query'].must_equal "INSERT INTO `items` (`price`, `name`) VALUES (?, ?)"
-      else
-        traces[1]['Query'].must_equal "INSERT INTO `items` (`name`, `price`) VALUES (?, ?)"
-      end
+
+      traces[1]['Query'].must_equal "INSERT INTO `items` (`price`, `name`) VALUES (?, ?)" ||
+                                    "INSERT INTO `items` (`name`, `price`) VALUES (?, ?)"
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]
       validate_event_keys(traces[2], @exit_kvs)
     end

--- a/test/instrumentation/sequel_mysql2_test.rb
+++ b/test/instrumentation/sequel_mysql2_test.rb
@@ -112,7 +112,7 @@ unless defined?(JRUBY_VERSION)
       items.count
 
       Oboe::API.start_trace('sequel_test', '', {}) do
-        items.insert(:name => 'abc', :price => 2.514461383352462)
+        items.insert(:name => 'abc', :price => 2.514)
         items.count
       end
 
@@ -126,8 +126,8 @@ unless defined?(JRUBY_VERSION)
       # SQL column/value order can vary between Ruby and gem versions
       # Use must_include to test against one or the other
       [
-       "INSERT INTO `items` (`price`, `name`) VALUES (2.51446138335246, 'abc')",
-       "INSERT INTO `items` (`name`, `price`) VALUES ('abc', 2.514461383352462)"
+       "INSERT INTO `items` (`price`, `name`) VALUES (2.514, 'abc')",
+       "INSERT INTO `items` (`name`, `price`) VALUES ('abc', 2.514)"
       ].must_include traces[1]['Query']
 
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]

--- a/test/instrumentation/sequel_mysql2_test.rb
+++ b/test/instrumentation/sequel_mysql2_test.rb
@@ -123,8 +123,13 @@ unless defined?(JRUBY_VERSION)
 
       validate_event_keys(traces[1], @entry_kvs)
 
-      traces[1]['Query'].must_equal "INSERT INTO `items` (`price`, `name`) VALUES (2.51446138335246, 'abc')" ||
-                                    "INSERT INTO `items` (`name`, `price`) VALUES ('abc', 2.514461383352462)"
+      # SQL column/value order can vary between Ruby and gem versions
+      # Use must_include to test against one or the other
+      [
+       "INSERT INTO `items` (`price`, `name`) VALUES (2.51446138335246, 'abc')",
+       "INSERT INTO `items` (`name`, `price`) VALUES ('abc', 2.514461383352462)"
+      ].must_include traces[1]['Query']
+
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]
       traces[2]['Layer'].must_equal "sequel"
       traces[2]['Label'].must_equal "exit"
@@ -148,8 +153,13 @@ unless defined?(JRUBY_VERSION)
 
       validate_event_keys(traces[1], @entry_kvs)
 
-      traces[1]['Query'].must_equal "INSERT INTO `items` (`price`, `name`) VALUES (?, ?)" ||
-                                    "INSERT INTO `items` (`name`, `price`) VALUES (?, ?)"
+      # SQL column/value order can vary between Ruby and gem versions
+      # Use must_include to test against one or the other
+      [
+       "INSERT INTO `items` (`price`, `name`) VALUES (?, ?)",
+       "INSERT INTO `items` (`name`, `price`) VALUES (?, ?)"
+      ].must_include traces[1]['Query']
+
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]
       validate_event_keys(traces[2], @exit_kvs)
     end

--- a/test/instrumentation/sequel_mysql_test.rb
+++ b/test/instrumentation/sequel_mysql_test.rb
@@ -26,7 +26,7 @@ unless defined?(JRUBY_VERSION)
         'Label' => 'entry',
         'Database' => 'travis_ci_test',
         'RemoteHost' => '127.0.0.1',
-        'RemotePort' => '3306' }
+        'RemotePort' => 3306 }
 
       @exit_kvs = { 'Layer' => 'sequel', 'Label' => 'exit' }
       @collect_backtraces = Oboe::Config[:sequel][:collect_backtraces]

--- a/test/instrumentation/sequel_mysql_test.rb
+++ b/test/instrumentation/sequel_mysql_test.rb
@@ -122,11 +122,9 @@ unless defined?(JRUBY_VERSION)
       validate_outer_layers(traces, 'sequel_test')
 
       validate_event_keys(traces[1], @entry_kvs)
-      if RUBY_VERSION < "1.9"
-        traces[1]['Query'].must_equal "INSERT INTO `items` (`price`, `name`) VALUES (2.51446138335246, 'abc')"
-      else
-        traces[1]['Query'].must_equal "INSERT INTO `items` (`name`, `price`) VALUES ('abc', 2.514461383352462)"
-      end
+
+      traces[1]['Query'].must_equal "INSERT INTO `items` (`price`, `name`) VALUES (2.51446138335246, 'abc')" ||
+                                    "INSERT INTO `items` (`name`, `price`) VALUES ('abc', 2.514461383352462)"
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]
       traces[2]['Layer'].must_equal "sequel"
       traces[2]['Label'].must_equal "exit"
@@ -149,11 +147,9 @@ unless defined?(JRUBY_VERSION)
       validate_outer_layers(traces, 'sequel_test')
 
       validate_event_keys(traces[1], @entry_kvs)
-      if RUBY_VERSION < "1.9"
-        traces[1]['Query'].must_equal "INSERT INTO `items` (`price`, `name`) VALUES (?, ?)"
-      else
-        traces[1]['Query'].must_equal "INSERT INTO `items` (`name`, `price`) VALUES (?, ?)"
-      end
+
+      traces[1]['Query'].must_equal "INSERT INTO `items` (`price`, `name`) VALUES (?, ?)" ||
+                                    "INSERT INTO `items` (`name`, `price`) VALUES (?, ?)"
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]
       validate_event_keys(traces[2], @exit_kvs)
     end

--- a/test/instrumentation/sequel_mysql_test.rb
+++ b/test/instrumentation/sequel_mysql_test.rb
@@ -112,7 +112,7 @@ unless defined?(JRUBY_VERSION)
       items.count
 
       Oboe::API.start_trace('sequel_test', '', {}) do
-        items.insert(:name => 'abc', :price => 2.514461383352462)
+        items.insert(:name => 'abc', :price => 2.514)
         items.count
       end
 
@@ -126,8 +126,8 @@ unless defined?(JRUBY_VERSION)
       # SQL column/value order can vary between Ruby and gem versions
       # Use must_include to test against one or the other
       [
-       "INSERT INTO `items` (`price`, `name`) VALUES (2.51446138335246, 'abc')",
-       "INSERT INTO `items` (`name`, `price`) VALUES ('abc', 2.514461383352462)"
+       "INSERT INTO `items` (`price`, `name`) VALUES (2.514, 'abc')",
+       "INSERT INTO `items` (`name`, `price`) VALUES ('abc', 2.514)"
       ].must_include traces[1]['Query']
 
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]

--- a/test/instrumentation/sequel_mysql_test.rb
+++ b/test/instrumentation/sequel_mysql_test.rb
@@ -123,8 +123,13 @@ unless defined?(JRUBY_VERSION)
 
       validate_event_keys(traces[1], @entry_kvs)
 
-      traces[1]['Query'].must_equal "INSERT INTO `items` (`price`, `name`) VALUES (2.51446138335246, 'abc')" ||
-                                    "INSERT INTO `items` (`name`, `price`) VALUES ('abc', 2.514461383352462)"
+      # SQL column/value order can vary between Ruby and gem versions
+      # Use must_include to test against one or the other
+      [
+       "INSERT INTO `items` (`price`, `name`) VALUES (2.51446138335246, 'abc')",
+       "INSERT INTO `items` (`name`, `price`) VALUES ('abc', 2.514461383352462)"
+      ].must_include traces[1]['Query']
+
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]
       traces[2]['Layer'].must_equal "sequel"
       traces[2]['Label'].must_equal "exit"
@@ -148,8 +153,13 @@ unless defined?(JRUBY_VERSION)
 
       validate_event_keys(traces[1], @entry_kvs)
 
-      traces[1]['Query'].must_equal "INSERT INTO `items` (`price`, `name`) VALUES (?, ?)" ||
-                                    "INSERT INTO `items` (`name`, `price`) VALUES (?, ?)"
+      # SQL column/value order can vary between Ruby and gem versions
+      # Use must_include to test against one or the other
+      [
+       "INSERT INTO `items` (`price`, `name`) VALUES (?, ?)",
+       "INSERT INTO `items` (`name`, `price`) VALUES (?, ?)"
+      ].must_include traces[1]['Query']
+
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]
       validate_event_keys(traces[2], @exit_kvs)
     end

--- a/test/instrumentation/sequel_pg_test.rb
+++ b/test/instrumentation/sequel_pg_test.rb
@@ -114,7 +114,7 @@ unless defined?(JRUBY_VERSION)
       PG_DB.primary_key(:items)
 
       Oboe::API.start_trace('sequel_test', '', {}) do
-        items.insert(:name => 'abc', :price => 2.514461383352462)
+        items.insert(:name => 'abc', :price => 2.514)
         items.count
       end
 
@@ -128,8 +128,8 @@ unless defined?(JRUBY_VERSION)
       # SQL column/value order can vary between Ruby and gem versions
       # Use must_include to test against one or the other
       [
-       "INSERT INTO \"items\" (\"price\", \"name\") VALUES (2.51446138335246, 'abc') RETURNING \"id\"",
-       "INSERT INTO \"items\" (\"name\", \"price\") VALUES ('abc', 2.514461383352462) RETURNING \"id\""
+       "INSERT INTO \"items\" (\"price\", \"name\") VALUES (2.514, 'abc') RETURNING \"id\"",
+       "INSERT INTO \"items\" (\"name\", \"price\") VALUES ('abc', 2.514) RETURNING \"id\""
       ].must_include traces[1]['Query']
 
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]

--- a/test/instrumentation/sequel_pg_test.rb
+++ b/test/instrumentation/sequel_pg_test.rb
@@ -26,7 +26,7 @@ unless defined?(JRUBY_VERSION)
         'Label' => 'entry',
         'Database' => 'travis_ci_test',
         'RemoteHost' => '127.0.0.1',
-        'RemotePort' => '5432' }
+        'RemotePort' => 5432 }
 
       @exit_kvs = { 'Layer' => 'sequel', 'Label' => 'exit' }
       @collect_backtraces = Oboe::Config[:sequel][:collect_backtraces]

--- a/test/instrumentation/sequel_pg_test.rb
+++ b/test/instrumentation/sequel_pg_test.rb
@@ -124,11 +124,9 @@ unless defined?(JRUBY_VERSION)
       validate_outer_layers(traces, 'sequel_test')
 
       validate_event_keys(traces[1], @entry_kvs)
-      if RUBY_VERSION < "1.9"
-        traces[1]['Query'].must_equal "INSERT INTO \"items\" (\"price\", \"name\") VALUES (2.51446138335246, 'abc') RETURNING \"id\""
-      else
-        traces[1]['Query'].must_equal "INSERT INTO \"items\" (\"name\", \"price\") VALUES ('abc', 2.514461383352462) RETURNING \"id\""
-      end
+
+      traces[1]['Query'].must_equal "INSERT INTO \"items\" (\"price\", \"name\") VALUES (2.51446138335246, 'abc') RETURNING \"id\"" ||
+                                    "INSERT INTO \"items\" (\"name\", \"price\") VALUES ('abc', 2.514461383352462) RETURNING \"id\""
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]
       traces[2]['Layer'].must_equal "sequel"
       traces[2]['Label'].must_equal "exit"
@@ -153,11 +151,9 @@ unless defined?(JRUBY_VERSION)
       validate_outer_layers(traces, 'sequel_test')
 
       validate_event_keys(traces[1], @entry_kvs)
-      if RUBY_VERSION < "1.9"
-        traces[1]['Query'].must_equal "INSERT INTO \"items\" (\"price\", \"name\") VALUES (?, ?) RETURNING \"id\""
-      else
-        traces[1]['Query'].must_equal "INSERT INTO \"items\" (\"name\", \"price\") VALUES (?, ?) RETURNING \"id\""
-      end
+
+      traces[1]['Query'].must_equal "INSERT INTO \"items\" (\"price\", \"name\") VALUES (?, ?) RETURNING \"id\"" ||
+                                    "INSERT INTO \"items\" (\"name\", \"price\") VALUES (?, ?) RETURNING \"id\""
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]
       validate_event_keys(traces[2], @exit_kvs)
     end

--- a/test/instrumentation/sequel_pg_test.rb
+++ b/test/instrumentation/sequel_pg_test.rb
@@ -125,8 +125,13 @@ unless defined?(JRUBY_VERSION)
 
       validate_event_keys(traces[1], @entry_kvs)
 
-      traces[1]['Query'].must_equal "INSERT INTO \"items\" (\"price\", \"name\") VALUES (2.51446138335246, 'abc') RETURNING \"id\"" ||
-                                    "INSERT INTO \"items\" (\"name\", \"price\") VALUES ('abc', 2.514461383352462) RETURNING \"id\""
+      # SQL column/value order can vary between Ruby and gem versions
+      # Use must_include to test against one or the other
+      [
+       "INSERT INTO \"items\" (\"price\", \"name\") VALUES (2.51446138335246, 'abc') RETURNING \"id\"",
+       "INSERT INTO \"items\" (\"name\", \"price\") VALUES ('abc', 2.514461383352462) RETURNING \"id\""
+      ].must_include traces[1]['Query']
+
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]
       traces[2]['Layer'].must_equal "sequel"
       traces[2]['Label'].must_equal "exit"
@@ -152,8 +157,13 @@ unless defined?(JRUBY_VERSION)
 
       validate_event_keys(traces[1], @entry_kvs)
 
-      traces[1]['Query'].must_equal "INSERT INTO \"items\" (\"price\", \"name\") VALUES (?, ?) RETURNING \"id\"" ||
-                                    "INSERT INTO \"items\" (\"name\", \"price\") VALUES (?, ?) RETURNING \"id\""
+      # SQL column/value order can vary between Ruby and gem versions
+      # Use must_include to test against one or the other
+      [
+        "INSERT INTO \"items\" (\"price\", \"name\") VALUES (?, ?) RETURNING \"id\"",
+        "INSERT INTO \"items\" (\"name\", \"price\") VALUES (?, ?) RETURNING \"id\""
+      ].must_include traces[1]['Query']
+
       traces[1].has_key?('Backtrace').must_equal Oboe::Config[:sequel][:collect_backtraces]
       validate_event_keys(traces[2], @exit_kvs)
     end

--- a/test/instrumentation/typhoeus_test.rb
+++ b/test/instrumentation/typhoeus_test.rb
@@ -36,12 +36,12 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
     traces[2]['Layer'].must_equal 'typhoeus'
     traces[2]['Label'].must_equal 'info'
-    traces[2]['IsService'].must_equal '1'
+    traces[2]['IsService'].must_equal 1
     traces[2]['RemoteProtocol'].downcase.must_equal 'http'
     traces[2]['RemoteHost'].must_equal 'www.appneta.com'
     traces[2]['ServiceArg'].must_equal '/products/traceview/'
     traces[2]['HTTPMethod'].must_equal 'get'
-    traces[2]['HTTPStatus'].must_equal '200'
+    traces[2]['HTTPStatus'].must_equal 200
 
     traces[3]['Layer'].must_equal 'typhoeus'
     traces[3]['Label'].must_equal 'exit'
@@ -63,13 +63,13 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
     traces[2]['Layer'].must_equal 'typhoeus'
     traces[2]['Label'].must_equal 'info'
-    traces[2]['IsService'].must_equal '1'
+    traces[2]['IsService'].must_equal 1
     traces[2]['RemoteProtocol'].downcase.must_equal 'https'
     traces[2]['RemoteHost'].must_equal 'internal.tv.appneta.com'
-    traces[2]['RemotePort'].must_equal '443'
+    traces[2]['RemotePort'].must_equal 443
     traces[2]['ServiceArg'].must_equal '/api-v2/log_message'
     traces[2]['HTTPMethod'].must_equal 'post'
-    traces[2]['HTTPStatus'].must_equal '302'
+    traces[2]['HTTPStatus'].must_equal 302
 
     traces[3]['Layer'].must_equal 'typhoeus'
     traces[3]['Label'].must_equal 'exit'
@@ -91,13 +91,13 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
     traces[2]['Layer'].must_equal 'typhoeus'
     traces[2]['Label'].must_equal 'info'
-    traces[2]['IsService'].must_equal '1'
+    traces[2]['IsService'].must_equal 1
     traces[2]['RemoteProtocol'].downcase.must_equal 'https'
     traces[2]['RemoteHost'].must_equal 'internal.tv.appneta.com'
-    traces[2]['RemotePort'].must_equal '443'
+    traces[2]['RemotePort'].must_equal 443
     traces[2]['ServiceArg'].must_equal '/api-v2/log_message'
     traces[2]['HTTPMethod'].must_equal 'put'
-    traces[2]['HTTPStatus'].must_equal '405'
+    traces[2]['HTTPStatus'].must_equal 405
 
     traces[3]['Layer'].must_equal 'typhoeus'
     traces[3]['Label'].must_equal 'exit'
@@ -118,13 +118,13 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
     traces[2]['Layer'].must_equal 'typhoeus'
     traces[2]['Label'].must_equal 'info'
-    traces[2]['IsService'].must_equal '1'
+    traces[2]['IsService'].must_equal 1
     traces[2]['RemoteProtocol'].downcase.must_equal 'https'
     traces[2]['RemoteHost'].must_equal 'internal.tv.appneta.com'
-    traces[2]['RemotePort'].must_equal '443'
+    traces[2]['RemotePort'].must_equal 443
     traces[2]['ServiceArg'].must_equal '/api-v2/log_message'
     traces[2]['HTTPMethod'].must_equal 'delete'
-    traces[2]['HTTPStatus'].must_equal '405'
+    traces[2]['HTTPStatus'].must_equal 405
 
     traces[3]['Layer'].must_equal 'typhoeus'
     traces[3]['Label'].must_equal 'exit'
@@ -145,12 +145,12 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
     traces[2]['Layer'].must_equal 'typhoeus'
     traces[2]['Label'].must_equal 'info'
-    traces[2]['IsService'].must_equal '1'
+    traces[2]['IsService'].must_equal 1
     traces[2]['RemoteProtocol'].downcase.must_equal 'http'
     traces[2]['RemoteHost'].must_equal 'www.appneta.com'
     traces[2]['ServiceArg'].must_equal '/'
     traces[2]['HTTPMethod'].must_equal 'head'
-    traces[2]['HTTPStatus'].must_equal '200'
+    traces[2]['HTTPStatus'].must_equal 200
 
     traces[3]['Layer'].must_equal 'typhoeus'
     traces[3]['Label'].must_equal 'exit'
@@ -171,12 +171,12 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
     traces[2]['Layer'].must_equal 'typhoeus'
     traces[2]['Label'].must_equal 'info'
-    traces[2]['IsService'].must_equal '1'
+    traces[2]['IsService'].must_equal 1
     traces[2]['RemoteProtocol'].downcase.must_equal 'http'
     traces[2]['RemoteHost'].must_equal 'www.gameface.in'
     traces[2]['ServiceArg'].must_equal '/gamers'
     traces[2]['HTTPMethod'].must_equal 'get'
-    traces[2]['HTTPStatus'].must_equal '200'
+    traces[2]['HTTPStatus'].must_equal 200
 
     traces[3]['Layer'].must_equal 'typhoeus'
     traces[3]['Label'].must_equal 'exit'
@@ -222,13 +222,13 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
     traces[4]['Layer'].must_equal 'typhoeus'
     traces[4]['Label'].must_equal 'info'
-    traces[4]['IsService'].must_equal '1'
+    traces[4]['IsService'].must_equal 1
     traces[4]['RemoteProtocol'].downcase.must_equal 'http'
     traces[4]['RemoteHost'].must_equal '127.0.0.1'
-    traces[4]['RemotePort'].must_equal '8000'
+    traces[4]['RemotePort'].must_equal 8000
     traces[4]['ServiceArg'].must_equal '/'
     traces[4]['HTTPMethod'].must_equal 'get'
-    traces[4]['HTTPStatus'].must_equal '200'
+    traces[4]['HTTPStatus'].must_equal 200
 
     traces[5]['Layer'].must_equal 'typhoeus'
     traces[5]['Label'].must_equal 'exit'
@@ -252,12 +252,12 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
     traces[3]['Layer'].must_equal 'typhoeus'
     traces[3]['Label'].must_equal 'info'
-    traces[3]['IsService'].must_equal '1'
+    traces[3]['IsService'].must_equal 1
     traces[3]['RemoteProtocol'].downcase.must_equal 'http'
     traces[3]['RemoteHost'].must_equal 'thisdomaindoesntexisthopefully.asdf'
     traces[3]['ServiceArg'].must_equal '/products/traceview/'
     traces[3]['HTTPMethod'].must_equal 'get'
-    traces[3]['HTTPStatus'].must_equal '0'
+    traces[3]['HTTPStatus'].must_equal 0
 
     traces[3]['Layer'].must_equal 'typhoeus'
     traces[3]['Label'].must_equal 'info'

--- a/test/support/liboboe_settings_test.rb
+++ b/test/support/liboboe_settings_test.rb
@@ -53,7 +53,7 @@ unless defined?(JRUBY_VERSION)
       result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
 
       # Class
-      report_kvs[:TestData] = Minitest
+      report_kvs[:TestData] = Oboe::Reporter
       result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
 
       # FalseClass
@@ -74,6 +74,10 @@ unless defined?(JRUBY_VERSION)
 
       # Integer
       report_kvs[:TestData] = 1
+      result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
+
+      # Module
+      report_kvs[:TestData] = Oboe
       result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
 
       # NilClass

--- a/test/support/liboboe_settings_test.rb
+++ b/test/support/liboboe_settings_test.rb
@@ -37,10 +37,16 @@ unless defined?(JRUBY_VERSION)
       validate_outer_layers(traces, 'rack')
 
       kvs = {}
-      kvs["SampleRate"] = "1000000"
-      kvs["SampleSource"] = OBOE_SAMPLE_RATE_SOURCE_FILE.to_s
+      kvs["SampleRate"] = 1000000
+      kvs["SampleSource"] = OBOE_SAMPLE_RATE_SOURCE_FILE
       validate_event_keys(traces[0], kvs)
 
     end
+  end
+
+  def validate_datatypes_support
+
+    Oboe::API.log_event('test_layer',
+  end
   end
 end

--- a/test/support/liboboe_settings_test.rb
+++ b/test/support/liboboe_settings_test.rb
@@ -40,13 +40,62 @@ unless defined?(JRUBY_VERSION)
       kvs["SampleRate"] = 1000000
       kvs["SampleSource"] = OBOE_SAMPLE_RATE_SOURCE_FILE
       validate_event_keys(traces[0], kvs)
+    end
 
+    # Test logging of all Ruby datatypes against the SWIG wrapper
+    # of addInfo which only has four overloads.
+    def test_swig_datatypes_conversion
+      event = Oboe::Context.createEvent
+      report_kvs = {}
+
+      # Array
+      report_kvs[:TestData] = [0, 1, 2, 5, 7.0]
+      result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
+
+      # Class
+      report_kvs[:TestData] = Minitest
+      result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
+
+      # FalseClass
+      report_kvs[:TestData] = false
+      result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
+
+      # Fixnum
+      report_kvs[:TestData] = 1_873_293_293
+      result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
+
+      # Float
+      report_kvs[:TestData] = 1.0001
+      result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
+
+      # Hash
+      report_kvs[:TestData] = Hash.new
+      result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
+
+      # Integer
+      report_kvs[:TestData] = 1
+      result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
+
+      # NilClass
+      report_kvs[:TestData] = nil
+      result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
+
+      # Set
+      report_kvs[:TestData] = Set.new(1..10)
+      result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
+
+      # String
+      report_kvs[:TestData] = 'test value'
+      result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
+
+      # Symbol
+      report_kvs[:TestData] = :TestValue
+      result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
+
+      # TrueClass
+      report_kvs[:TestData] = true
+      result = Oboe::API.log_event('test_layer', 'entry', event, report_kvs)
     end
   end
 
-  def validate_datatypes_support
-
-    Oboe::API.log_event('test_layer',
-  end
-  end
 end


### PR DESCRIPTION
We currently report all values as strings which causes some inefficiencies server-side.  The Ruby instrumentation should be updated to report the supported data types as per SWIG.

https://github.com/tracelytics/oboe-ruby/blob/master/lib/oboe/api/logging.rb#L184