### PR TITLE
Avoid double tracing rack layer for nested apps

### DIFF
--- a/lib/oboe/inst/rack.rb
+++ b/lib/oboe/inst/rack.rb
@@ -47,6 +47,11 @@ module Oboe
     end
 
     def call(env)
+      # If we're already tracing a rack layer, dont't start another one.
+      if Oboe.tracing? && Oboe.layer == 'rack'
+        return @app.call(env)
+      end
+
       req = ::Rack::Request.new(env)
 
       report_kvs = {}

--- a/test/frameworks/apps/grape_nested.rb
+++ b/test/frameworks/apps/grape_nested.rb
@@ -1,0 +1,30 @@
+require 'grape'
+
+class Wrapper < Grape::API
+  class GrapeSimple < Grape::API
+    rescue_from :all do |e|
+      error_response({ message: "rescued from #{e.class.name}" })
+    end
+
+    get '/json_endpoint' do
+      present({ :test => true })
+    end
+
+    get "/break" do
+      raise Exception.new("This should have http status code 500!")
+    end
+
+    get "/error" do
+      error!("This is a error with 'error'!")
+    end
+
+    get "/breakstring" do
+      raise "This should have http status code 500!"
+    end
+  end
+end
+
+class GrapeNested < Grape::API
+  mount Wrapper::GrapeSimple
+end
+

--- a/test/frameworks/padrino_test.rb
+++ b/test/frameworks/padrino_test.rb
@@ -13,17 +13,17 @@ if RUBY_VERSION >= '1.9.3'
       r = get "/render"
 
       traces = get_all_traces
-      traces.count.must_equal 8
+      traces.count.must_equal 9
 
       validate_outer_layers(traces, 'rack')
 
-      traces[1]['Layer'].must_equal "padrino"
-      traces[6]['Controller'].must_equal "SimpleDemo"
-      traces[7]['Label'].must_equal "exit"
+      traces[2]['Layer'].must_equal "padrino"
+      traces[7]['Controller'].must_equal "SimpleDemo"
+      traces[8]['Label'].must_equal "exit"
 
       # Validate the existence of the response header
       r.headers.key?('X-Trace').must_equal true
-      r.headers['X-Trace'].must_equal traces[7]['X-Trace']
+      r.headers['X-Trace'].must_equal traces[8]['X-Trace']
     end
   end
 end

--- a/test/frameworks/sinatra_test.rb
+++ b/test/frameworks/sinatra_test.rb
@@ -12,18 +12,18 @@ describe Sinatra do
     r = get "/render"
 
     traces = get_all_traces
-    traces.count.must_equal 8
+    traces.count.must_equal 9
 
     validate_outer_layers(traces, 'rack')
 
-    traces[1]['Layer'].must_equal "sinatra"
-    traces[3]['Label'].must_equal "profile_entry"
-    traces[6]['Controller'].must_equal "SinatraSimple"
-    traces[7]['Label'].must_equal "exit"
+    traces[2]['Layer'].must_equal "sinatra"
+    traces[4]['Label'].must_equal "profile_entry"
+    traces[7]['Controller'].must_equal "SinatraSimple"
+    traces[8]['Label'].must_equal "exit"
 
     # Validate the existence of the response header
     r.headers.key?('X-Trace').must_equal true
-    r.headers['X-Trace'].must_equal traces[7]['X-Trace']
+    r.headers['X-Trace'].must_equal traces[8]['X-Trace']
   end
 end
 

--- a/test/instrumentation/rack_test.rb
+++ b/test/instrumentation/rack_test.rb
@@ -24,7 +24,7 @@ class RackTestApp < Minitest::Test
     get "/lobster"
 
     traces = get_all_traces
-    traces.count.must_equal 2
+    traces.count.must_equal 3
 
     validate_outer_layers(traces, 'rack')
 
@@ -33,8 +33,7 @@ class RackTestApp < Minitest::Test
     validate_event_keys(traces[0], kvs)
 
     kvs.clear
-    kvs["Label"] = "exit"
-    kvs["Status"] = "200"
+    kvs["Label"] = "info"
     kvs["HTTP-Host"] = "example.org"
     kvs["Port"] = "80"
     kvs["Proto"] = "http"
@@ -47,6 +46,9 @@ class RackTestApp < Minitest::Test
     assert traces[0].has_key?('SampleSource')
     assert traces[1].has_key?('ProcessID')
     assert traces[1].has_key?('ThreadID')
+
+    assert traces[2]["Label"] == 'exit'
+    assert traces[2]["Status"] == "200"
 
     assert last_response.ok?
 

--- a/test/instrumentation/typhoeus_test.rb
+++ b/test/instrumentation/typhoeus_test.rb
@@ -204,34 +204,37 @@ describe Oboe::Inst::TyphoeusRequestOps do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 7
+    traces.count.must_equal 8
 
     validate_outer_layers(traces, 'outer')
 
+    #require 'byebug'
+    #debugger
+
     traces[2]['Layer'].must_equal 'rack'
     traces[2]['Label'].must_equal 'entry'
-    traces[3]['Layer'].must_equal 'rack'
-    traces[3]['Label'].must_equal 'exit'
+    traces[4]['Layer'].must_equal 'rack'
+    traces[4]['Label'].must_equal 'exit'
 
     # Verify typhoeus info edges to inner exit
-    traces[5]['Edge'].must_equal traces[4]['X-Trace'][42...58]
+    traces[6]['Edge'].must_equal traces[5]['X-Trace'][42...58]
 
     # Verify typhoeus events
     traces[1]['Layer'].must_equal 'typhoeus'
     traces[1].key?('Backtrace').must_equal Oboe::Config[:typhoeus][:collect_backtraces]
 
-    traces[4]['Layer'].must_equal 'typhoeus'
-    traces[4]['Label'].must_equal 'info'
-    traces[4]['IsService'].must_equal '1'
-    traces[4]['RemoteProtocol'].downcase.must_equal 'http'
-    traces[4]['RemoteHost'].must_equal '127.0.0.1'
-    traces[4]['RemotePort'].must_equal '8000'
-    traces[4]['ServiceArg'].must_equal '/'
-    traces[4]['HTTPMethod'].must_equal 'get'
-    traces[4]['HTTPStatus'].must_equal '200'
-
     traces[5]['Layer'].must_equal 'typhoeus'
-    traces[5]['Label'].must_equal 'exit'
+    traces[5]['Label'].must_equal 'info'
+    traces[5]['IsService'].must_equal '1'
+    traces[5]['RemoteProtocol'].downcase.must_equal 'http'
+    traces[5]['RemoteHost'].must_equal '127.0.0.1'
+    traces[5]['RemotePort'].must_equal '8000'
+    traces[5]['ServiceArg'].must_equal '/'
+    traces[5]['HTTPMethod'].must_equal 'get'
+    traces[5]['HTTPStatus'].must_equal '200'
+
+    traces[6]['Layer'].must_equal 'typhoeus'
+    traces[6]['Label'].must_equal 'exit'
   end
 
   it 'should trace a typhoeus GET request with DNS error' do

--- a/test/support/liboboe_settings_test.rb
+++ b/test/support/liboboe_settings_test.rb
@@ -32,7 +32,7 @@ unless defined?(JRUBY_VERSION)
       get "/lobster"
 
       traces = get_all_traces
-      traces.count.must_equal 2
+      traces.count.must_equal 3
 
       validate_outer_layers(traces, 'rack')
 


### PR DESCRIPTION
For an app with nested apps mounted underneath (e.g. Rails with Grape or Grape with Grape), we currently trace rack for each app.  This is unnecessary can be summed with a single rack layer.