### PR TITLE
Protect against unknown data type reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,9 @@ group :development, :test do
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'rack-test'
-  gem 'appraisal'
+  if RUBY_VERSION > '1.8.7'
+    gem 'appraisal'
+  end
 end
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,10 @@
 require 'rubygems'
 require 'bundler/setup'
 require 'rake/testtask'
-require 'appraisal'
+
+if RUBY_VERSION > '1.8.7'
+  require 'appraisal'
+end
 
 Rake::TestTask.new do |t|
   t.libs << "test"

--- a/lib/oboe/api/logging.rb
+++ b/lib/oboe/api/logging.rb
@@ -181,17 +181,22 @@ module Oboe
           Oboe.layer = nil   if label == 'exit'
 
           opts.each do |k, v|
+            value = nil
+
             if valid_key? k
-              if [Class, Module, Symbol, Array, Hash,
-                  TrueClass, FalseClass].include?(v.class)
-                value = v.to_s
+              if [Integer, Float, Fixnum, NilClass, String].include?(v.class)
+                value = v
               elsif v.class == Set
                 value = v.to_a.to_s
               else
-                value = v
+                value = v.to_s if v.respond_to?(:to_s)
               end
 
-              event.addInfo(k.to_s, value)
+              begin
+                event.addInfo(k.to_s, value)
+              rescue ArgumentError => e
+                Oboe.logger.debug "[oboe/debug] Couldn't add event KV: #{v.class}"
+              end
             end
           end if !opts.nil? && opts.any?
 


### PR DESCRIPTION
Although we have thorough checks and tests for the data types reported via `addInfo`, we should add greater safeties against unknowns.  If an unsupported data type is hit, it currently outputs a stack trace similar to the following:

![screenshot 2015-03-06 19 29 37](https://cloud.githubusercontent.com/assets/395132/6531150/26b455b6-c437-11e4-9d8e-f690277e39ea.png)
