### PR TITLE
Support Puma Webserver on Heroku

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ https://github.com/appneta/oboe-ruby/releases
 
 Dates in this file are in the format MM/DD/YYYY.
 
+# oboe 2.7.13.3
+
+This build release includes:
+
+* Protect against unknown data type reporting: #106
+
+Pushed to Rubygems:
+
+https://rubygems.org/gems/oboe/versions/2.7.13.3
+https://rubygems.org/gems/oboe/versions/2.7.13.3-java
+
 # oboe 2.7.12.1
 
 This patch release includes:

--- a/lib/oboe/api/logging.rb
+++ b/lib/oboe/api/logging.rb
@@ -200,7 +200,7 @@ module Oboe
             end
           end if !opts.nil? && opts.any?
 
-          Oboe::Reporter.sendReport(event) if Oboe.loaded
+          Oboe::Reporter.sendReport(event)
         end
       end
     end

--- a/lib/oboe/base.rb
+++ b/lib/oboe/base.rb
@@ -183,7 +183,12 @@ module OboeBase
   # Determines if we are running under a forking webserver
   #
   def forking_webserver?
-    (defined?(::Unicorn) && ($PROGRAM_NAME =~ /unicorn/i)) ? true : false
+    if (defined?(::Unicorn) && ($PROGRAM_NAME =~ /unicorn/i)) ||
+       (defined?(::Puma)    && ($PROGRAM_NAME =~ /puma/i))
+      true
+    else
+      false
+    end
   end
 
   ##

--- a/lib/oboe/version.rb
+++ b/lib/oboe/version.rb
@@ -8,8 +8,8 @@ module Oboe
   module Version
     MAJOR = 2
     MINOR = 7
-    PATCH = 12
-    BUILD = 1
+    PATCH = 13
+    BUILD = 3
 
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')
   end


### PR DESCRIPTION
We currently don't support Puma as it forks off workers. Connections for the SSL Reporter are no longer valid.