### PR TITLE
Instrument rest-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'faraday'
 gem 'excon'
 gem 'typhoeus'
 gem 'sequel'
+gem 'rest-client'
 
 # Database adapter gems needed by sequel
 if defined?(JRUBY_VERSION)

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,11 @@ gem 'faraday'
 gem 'excon'
 gem 'typhoeus'
 gem 'sequel'
-gem 'rest-client'
+if RUBY_VERSION >= '1.9.3'
+  # rest-client depends on mime-types gem which only supports
+  # ruby 1.9.3 and up
+  gem 'rest-client'
+end
 
 # Database adapter gems needed by sequel
 if defined?(JRUBY_VERSION)

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'minitest'
+  gem 'minitest', "5.5.1"
   gem 'minitest-reporters'
   gem 'rack-test'
   if RUBY_VERSION > '1.8.7'
@@ -59,6 +59,12 @@ if RUBY_VERSION >= '1.9'
   gem 'em-synchrony'
   gem 'em-http-request'
 end
+
+# FIXME:Newer activesupport and i18n now require
+# ruby >= 1.9.3.  We limit their versions temporarily
+# until we figure out a better gem matrix for tests.
+gem "activesupport", "<= 4.0.4"
+gem "i18n", "< 0.7.0"
 
 unless defined?(JRUBY_VERSION)
   gem 'memcached', '1.7.2' if RUBY_VERSION < '2.0.0'

--- a/lib/oboe/config.rb
+++ b/lib/oboe/config.rb
@@ -14,7 +14,7 @@ module Oboe
     @@instrumentation = [:action_controller, :action_view, :active_record,
                          :cassandra, :dalli, :em_http_request, :faraday, :grape, :nethttp,
                          :memcached, :memcache, :mongo, :moped, :rack, :redis, :resque,
-                         :sequel, :typhoeus]
+                         :rest_client, :sequel, :typhoeus]
     ##
     # Return the raw nested hash.
     #
@@ -50,6 +50,7 @@ module Oboe
       Oboe::Config[:nethttp][:collect_backtraces] = true
       Oboe::Config[:redis][:collect_backtraces] = false
       Oboe::Config[:resque][:collect_backtraces] = true
+      Oboe::Config[:rest_client][:collect_backtraces] = true
       Oboe::Config[:sequel][:collect_backtraces] = true
       Oboe::Config[:typhoeus][:collect_backtraces] = false
 

--- a/lib/oboe/config.rb
+++ b/lib/oboe/config.rb
@@ -50,7 +50,7 @@ module Oboe
       Oboe::Config[:nethttp][:collect_backtraces] = true
       Oboe::Config[:redis][:collect_backtraces] = false
       Oboe::Config[:resque][:collect_backtraces] = true
-      Oboe::Config[:rest_client][:collect_backtraces] = true
+      Oboe::Config[:rest_client][:collect_backtraces] = false
       Oboe::Config[:sequel][:collect_backtraces] = true
       Oboe::Config[:typhoeus][:collect_backtraces] = false
 

--- a/lib/oboe/inst/http.rb
+++ b/lib/oboe/inst/http.rb
@@ -11,7 +11,7 @@ if Oboe::Config[:nethttp][:enabled]
       # If we're not tracing, just do a fast return
       # In the case of rest-client, we let it handle the timing
       # and service KVs.
-      if !Oboe.tracing? || !started? || Oboe.tracing_layer?("rest-client")
+      if !Oboe.tracing? || !started?
         return request_without_oboe(*args, &block)
       end
 

--- a/lib/oboe/inst/rest-client.rb
+++ b/lib/oboe/inst/rest-client.rb
@@ -5,6 +5,35 @@ module Oboe
         ::Oboe::Util.method_alias(klass, :execute, ::RestClient::Request)
       end
 
+      ##
+      # oboe_collect
+      #
+      # Used to collect up KVs to be reported
+      # to the TraceView dashboard.
+      #
+      def oboe_collect
+        kvs = {}
+        uri = parse_url_with_auth(@url)
+
+        kvs['Backtrace'] = Oboe::API.backtrace if Oboe::Config[:rest_client][:collect_backtraces]
+        kvs['IsService'] = 1
+        kvs['RemoteProtocol'] = (uri.scheme == 'https') ? 'HTTPS' : 'HTTP'
+        kvs['RemoteHost'] = uri.host
+        kvs['RemotePort'] = uri.port
+        kvs['ServiceArg'] = uri.request_uri
+        kvs['HTTPMethod'] = @method.to_s.upcase
+        kvs
+      rescue => e
+        Oboe.logger.debug "[oboe/debug] Problem capturing rest-client KVs: #{e.message}"
+        Oboe.logger.debug e.backtrace if e.respond_to?(:backtrace) && Oboe::Config[:verbose]
+        return kvs
+      end
+
+      ##
+      # execute_with_oboe
+      #
+      # The wrapper method for RestClient::Request.execute
+      #
       def execute_with_oboe & block
         # If we're not tracing or if rest-client is doing
         # nested loops (following redirects), then just
@@ -13,58 +42,41 @@ module Oboe
           return execute_without_oboe(&block)
         end
 
-        Oboe::API.log_entry('rest-client')
-
-        blacklisted = Oboe::API.blacklisted?(@url)
-        context = Oboe::Context.toString
-        task_id = Oboe::XTrace.task_id(context)
-
-        # Avoid cross host tracing for blacklisted domains
-        # Conditionally add the X-Trace header to the outgoing request
-        @headers['X-Trace'] = context unless blacklisted
-
-        result = execute_without_oboe(&block)
-
-        kvs = {}
-        kvs[:HTTPStatus] = result.code
-        kvs['Backtrace'] = Oboe::API.backtrace if Oboe::Config[:rest_client][:collect_backtraces]
-
         begin
-          uri = parse_url_with_auth(@url)
+          Oboe::API.log_entry('rest-client')
 
-          kvs['IsService'] = 1
-          kvs['RemoteProtocol'] = (uri.scheme == 'https') ? 'HTTPS' : 'HTTP'
-          kvs['RemoteHost'] = uri.host
-          kvs['RemotePort'] = uri.port
-          kvs['ServiceArg'] = uri.request_uri
-          kvs['HTTPMethod'] = @method.to_s.upcase
-          kvs['Blacklisted'] = true if blacklisted
-        rescue => e
-          Oboe.logger.debug "[oboe/debug] Problem capturing rest-client KVs: #{e.message}"
-          Oboe.logger.debug e.backtrace if e.respond_to?(:backtrace) && Oboe::Config[:verbose]
-        end
+          blacklisted = Oboe::API.blacklisted?(@url)
+          start_xtrace = Oboe::Context.toString
 
-        # Re-attach net::http edge unless it's blacklisted or if we don't have a
-        # valid X-Trace header
-        unless blacklisted
-          xtrace = result.headers[:x_trace]
+          # Try to grab KVs as early as possible in case an exception
+          # is raised and we don't get a chance to.
+          kvs = oboe_collect
 
-          if Oboe::XTrace.valid?(xtrace) && Oboe.tracing?
-
-            # Assure that we received back a valid X-Trace with the same task_id
-            if task_id == Oboe::XTrace.task_id(xtrace)
-              Oboe::Context.fromString(xtrace)
-            else
-              Oboe.logger.debug "Mismatched returned X-Trace ID: #{xtrace}"
-            end
+          # Avoid cross host tracing for blacklisted domains
+          # Conditionally add the X-Trace header to the outgoing request
+          if blacklisted
+            kvs['Blacklisted'] = true
+          else
+            @headers['X-Trace'] = start_xtrace
           end
-        end
 
-        Oboe::API.log_exit('rest-client', kvs)
+          # The core rest-client call
+          result = execute_without_oboe(&block)
+
+          kvs[:HTTPStatus] = result.code
+
+          # Re-attach net::http edge unless it's blacklisted or if we don't have a
+          # valid X-Trace header.  pickup_context will validate values.
+          unless blacklisted
+            Oboe::XTrace.continue_service_context(start_xtrace, result.headers[:x_trace])
+          end
+        rescue => e
+          Oboe::API.log_exception('rest-client', e)
+          raise e
+        ensure
+          Oboe::API.log_exit('rest-client', kvs)
+        end
         result
-      rescue => e
-        Oboe::API.log_exception('rest-client', e)
-        raise e
       end
     end
   end

--- a/lib/oboe/inst/rest-client.rb
+++ b/lib/oboe/inst/rest-client.rb
@@ -1,3 +1,5 @@
+require 'byebug'
+
 module Oboe
   module Inst
     module RestClientRequest
@@ -6,77 +8,22 @@ module Oboe
       end
 
       ##
-      # oboe_collect
-      #
-      # Used to collect up KVs to be reported
-      # to the TraceView dashboard.
-      #
-      def oboe_collect
-        kvs = {}
-        uri = parse_url_with_auth(@url)
-
-        kvs['Backtrace'] = Oboe::API.backtrace if Oboe::Config[:rest_client][:collect_backtraces]
-        kvs['IsService'] = 1
-        kvs['RemoteProtocol'] = (uri.scheme == 'https') ? 'HTTPS' : 'HTTP'
-        kvs['RemoteHost'] = uri.host
-        kvs['RemotePort'] = uri.port
-        kvs['ServiceArg'] = uri.request_uri
-        kvs['HTTPMethod'] = @method.to_s.upcase
-        kvs
-      rescue => e
-        Oboe.logger.debug "[oboe/debug] Problem capturing rest-client KVs: #{e.message}"
-        Oboe.logger.debug e.backtrace if e.respond_to?(:backtrace) && Oboe::Config[:verbose]
-        return kvs
-      end
-
-      ##
       # execute_with_oboe
       #
       # The wrapper method for RestClient::Request.execute
       #
       def execute_with_oboe & block
-        # If we're not tracing or if rest-client is doing
-        # nested loops (following redirects), then just
-        # do a fast return.
-        if !Oboe.tracing? || Oboe.tracing_layer?("rest-client")
-          return execute_without_oboe(&block)
-        end
+        kvs = {}
+        kvs['Backtrace'] = Oboe::API.backtrace if Oboe::Config[:rest_client][:collect_backtraces]
+        Oboe::API.log_entry("rest-client", kvs)
 
-        begin
-          Oboe::API.log_entry('rest-client')
-
-          blacklisted = Oboe::API.blacklisted?(@url)
-          start_xtrace = Oboe::Context.toString
-
-          # Try to grab KVs as early as possible in case an exception
-          # is raised and we don't get a chance to.
-          kvs = oboe_collect
-
-          # Avoid cross host tracing for blacklisted domains
-          # Conditionally add the X-Trace header to the outgoing request
-          if blacklisted
-            kvs['Blacklisted'] = true
-          else
-            @processed_headers['X-Trace'] = start_xtrace
-          end
-
-          # The core rest-client call
-          result = execute_without_oboe(&block)
-
-          kvs[:HTTPStatus] = result.code
-
-          # Re-attach net::http edge unless it's blacklisted or if we don't have a
-          # valid X-Trace header.  pickup_context will validate values.
-          unless blacklisted
-            Oboe::XTrace.continue_service_context(start_xtrace, result.headers[:x_trace])
-          end
-        rescue => e
-          Oboe::API.log_exception('rest-client', e)
-          raise e
-        ensure
-          Oboe::API.log_exit('rest-client', kvs)
-        end
-        result
+        # The core rest-client call
+        execute_without_oboe(&block)
+      rescue => e
+        Oboe::API.log_exception('rest-client', e)
+        raise e
+      ensure
+        Oboe::API.log_exit("rest-client")
       end
     end
   end

--- a/lib/oboe/inst/rest-client.rb
+++ b/lib/oboe/inst/rest-client.rb
@@ -1,0 +1,78 @@
+module Oboe
+  module Inst
+    module RestClientRequest
+      def self.included(klass)
+        ::Oboe::Util.method_alias(klass, :execute, ::RestClient::Request)
+      end
+
+      def execute_with_oboe & block
+        # If we're not tracing or if rest-client is doing
+        # nested loops (following redirects), then just
+        # do a fast return.
+        if !Oboe.tracing? || Oboe.tracing_layer?("rest-client")
+          return execute_without_oboe(&block)
+        end
+
+        Oboe::API.log_entry('rest-client')
+
+        blacklisted = Oboe::API.blacklisted?(@url)
+        context = Oboe::Context.toString
+        task_id = Oboe::XTrace.task_id(context)
+
+        # Avoid cross host tracing for blacklisted domains
+        # Conditionally add the X-Trace header to the outgoing request
+        @headers['X-Trace'] = context unless blacklisted
+
+        result = execute_without_oboe(&block)
+
+        kvs = {}
+        kvs[:HTTPStatus] = result.code
+        kvs['Backtrace'] = Oboe::API.backtrace if Oboe::Config[:rest_client][:collect_backtraces]
+
+        begin
+          uri = parse_url_with_auth(@url)
+
+          kvs['IsService'] = 1
+          kvs['RemoteProtocol'] = (uri.scheme == 'https') ? 'HTTPS' : 'HTTP'
+          kvs['RemoteHost'] = uri.host
+          kvs['RemotePort'] = uri.port
+          kvs['ServiceArg'] = uri.request_uri
+          kvs['HTTPMethod'] = @method.to_s.upcase
+          kvs['Blacklisted'] = true if blacklisted
+        rescue => e
+          Oboe.logger.debug "[oboe/debug] Problem capturing rest-client KVs: #{e.message}"
+          Oboe.logger.debug e.backtrace if e.respond_to?(:backtrace) && Oboe::Config[:verbose]
+        end
+
+        # Re-attach net::http edge unless it's blacklisted or if we don't have a
+        # valid X-Trace header
+        unless blacklisted
+          xtrace = result.headers[:x_trace]
+
+          if Oboe::XTrace.valid?(xtrace) && Oboe.tracing?
+
+            # Assure that we received back a valid X-Trace with the same task_id
+            if task_id == Oboe::XTrace.task_id(xtrace)
+              Oboe::Context.fromString(xtrace)
+            else
+              Oboe.logger.debug "Mismatched returned X-Trace ID: #{xtrace}"
+            end
+          end
+        end
+
+        Oboe::API.log_exit('rest-client', kvs)
+        result
+      rescue => e
+        Oboe::API.log_exception('rest-client', e)
+        raise e
+      end
+    end
+  end
+end
+
+if Oboe::Config[:rest_client][:enabled]
+  if defined?(::RestClient)
+    Oboe.logger.info '[oboe/loading] Instrumenting rest-client' if Oboe::Config[:verbose]
+    ::Oboe::Util.send_include(::RestClient::Request, ::Oboe::Inst::RestClientRequest)
+  end
+end

--- a/lib/oboe/inst/rest-client.rb
+++ b/lib/oboe/inst/rest-client.rb
@@ -57,7 +57,7 @@ module Oboe
           if blacklisted
             kvs['Blacklisted'] = true
           else
-            @headers['X-Trace'] = start_xtrace
+            @processed_headers['X-Trace'] = start_xtrace
           end
 
           # The core rest-client call

--- a/lib/oboe/inst/rest-client.rb
+++ b/lib/oboe/inst/rest-client.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-
 module Oboe
   module Inst
     module RestClientRequest

--- a/lib/oboe/util.rb
+++ b/lib/oboe/util.rb
@@ -154,14 +154,15 @@ module Oboe
           end
 
           # Report the instrumented libraries
-          platform_info['Ruby.Cassandra.Version'] = "Cassandra-#{::Cassandra.VERSION}" if defined?(::Cassandra)
-          platform_info['Ruby.Dalli.Version']     = "Dalli-#{::Dalli::VERSION}"        if defined?(::Dalli)
-          platform_info['Ruby.Faraday.Version']   = "Faraday-#{::Faraday::VERSION}"    if defined?(::Faraday)
-          platform_info['Ruby.MemCache.Version']  = "MemCache-#{::MemCache::VERSION}"  if defined?(::MemCache)
-          platform_info['Ruby.Moped.Version']     = "Moped-#{::Moped::VERSION}"        if defined?(::Moped)
-          platform_info['Ruby.Redis.Version']     = "Redis-#{::Redis::VERSION}"        if defined?(::Redis)
-          platform_info['Ruby.Resque.Version']    = "Resque-#{::Resque::VERSION}"      if defined?(::Resque)
-          platform_info['Ruby.Typhoeus.Version']  = "Typhoeus-#{::Typhoeus::VERSION}"  if defined?(::Typhoeus::VERSION)
+          platform_info['Ruby.Cassandra.Version']  = "Cassandra-#{::Cassandra.VERSION}"    if defined?(::Cassandra)
+          platform_info['Ruby.Dalli.Version']      = "Dalli-#{::Dalli::VERSION}"           if defined?(::Dalli)
+          platform_info['Ruby.Faraday.Version']    = "Faraday-#{::Faraday::VERSION}"       if defined?(::Faraday)
+          platform_info['Ruby.MemCache.Version']   = "MemCache-#{::MemCache::VERSION}"     if defined?(::MemCache)
+          platform_info['Ruby.Moped.Version']      = "Moped-#{::Moped::VERSION}"           if defined?(::Moped)
+          platform_info['Ruby.Redis.Version']      = "Redis-#{::Redis::VERSION}"           if defined?(::Redis)
+          platform_info['Ruby.Resque.Version']     = "Resque-#{::Resque::VERSION}"         if defined?(::Resque)
+          platform_info['Ruby.RestClient.Version'] = "RestClient-#{::RestClient::VERSION}" if defined?(::RestClient::VERSION)
+          platform_info['Ruby.Typhoeus.Version']   = "Typhoeus-#{::Typhoeus::VERSION}"     if defined?(::Typhoeus::VERSION)
 
           # Special case since the Mongo 1.x driver doesn't embed the version number in the gem directly
           if ::Gem.loaded_specs.key?('mongo')

--- a/lib/oboe/xtrace.rb
+++ b/lib/oboe/xtrace.rb
@@ -43,6 +43,33 @@ module Oboe
         Oboe.logger.debug e.backtrace
         return nil
       end
+
+      ##
+      # continue_service_context
+      #
+      # In the case of service calls such as external HTTP requests, we
+      # pass along X-Trace headers so that request context can be maintained
+      # across servers and applications.
+      #
+      # Remote requests can return a X-Trace header in which case we want
+      # to pickup on and continue the context in most cases.
+      #
+      # @start is the context just before the outgoing request
+      #
+      # @finish is the context returned to us (as an HTTP response header
+      # if that be the case)
+      #
+      def continue_service_context(start, finish)
+        if Oboe::XTrace.valid?(finish) && Oboe.tracing?
+
+          # Assure that we received back a valid X-Trace with the same task_id
+          if Oboe::XTrace.task_id(start) == Oboe::XTrace.task_id(finish)
+            Oboe::Context.fromString(finish)
+          else
+            Oboe.logger.debug "Mismatched returned X-Trace ID: #{finish}"
+          end
+        end
+      end
     end
   end
 end

--- a/lib/oboe/xtrace.rb
+++ b/lib/oboe/xtrace.rb
@@ -45,6 +45,21 @@ module Oboe
       end
 
       ##
+      # Oboe::XTrace.edge_id
+      #
+      # Extract and return the edge_id portion of an X-Trace ID
+      #
+      def edge_id(xtrace)
+        return nil unless Oboe::XTrace.valid?(xtrace)
+
+        xtrace[42..57]
+      rescue StandardError => e
+        Oboe.logger.debug e.message
+        Oboe.logger.debug e.backtrace
+        return nil
+      end
+
+      ##
       # continue_service_context
       #
       # In the case of service calls such as external HTTP requests, we

--- a/test/instrumentation/http_test.rb
+++ b/test/instrumentation/http_test.rb
@@ -34,6 +34,10 @@ describe Oboe::Inst do
     traces = get_all_traces
     traces.count.must_equal 5
 
+    # FIXME: We need to switch from making external calls to an internal test
+    # stack instead so we can validate cross-app traces.
+    # valid_edges?(traces).must_equal true
+
     validate_outer_layers(traces, 'net-http_test')
 
     traces[1]['Layer'].must_equal 'net-http'
@@ -55,6 +59,7 @@ describe Oboe::Inst do
 
     traces = get_all_traces
     traces.count.must_equal 5
+    valid_edges?(traces).must_equal true
 
     validate_outer_layers(traces, 'net-http_test')
 

--- a/test/instrumentation/rest-client_test.rb
+++ b/test/instrumentation/rest-client_test.rb
@@ -36,22 +36,31 @@ if RUBY_VERSION >= '1.9.3'
       end
 
       traces = get_all_traces
-      traces.count.must_equal 4
+      traces.count.must_equal 7
 
       validate_outer_layers(traces, 'rest_client_test')
 
       traces[1]['Layer'].must_equal 'rest-client'
       traces[1]['Label'].must_equal 'entry'
 
-      traces[2]['Layer'].must_equal 'rest-client'
-      traces[2]['Label'].must_equal 'exit'
-      traces[2]['IsService'].must_equal 1
-      traces[2]['RemoteProtocol'].must_equal 'HTTP'
-      traces[2]['RemoteHost'].must_equal 'gameface.in'
-      traces[2]['ServiceArg'].must_equal '/gamers'
-      traces[2]['HTTPMethod'].must_equal 'GET'
-      traces[2]['HTTPStatus'].must_equal 200
-      traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
+      traces[2]['Layer'].must_equal 'net-http'
+      traces[2]['Label'].must_equal 'entry'
+
+      traces[3]['Layer'].must_equal 'net-http'
+      traces[3]['Label'].must_equal 'info'
+      traces[3]['IsService'].must_equal 1
+      traces[3]['RemoteProtocol'].must_equal 'HTTP'
+      traces[3]['RemoteHost'].must_equal 'gameface.in'
+      traces[3]['ServiceArg'].must_equal '/gamers'
+      traces[3]['HTTPMethod'].must_equal 'GET'
+      traces[3]['HTTPStatus'].must_equal "200"
+      traces[3].key?('Backtrace').must_equal Oboe::Config[:nethttp][:collect_backtraces]
+
+      traces[4]['Layer'].must_equal 'net-http'
+      traces[4]['Label'].must_equal 'exit'
+
+      traces[5]['Layer'].must_equal 'rest-client'
+      traces[5]['Label'].must_equal 'exit'
 
       response.headers.key?(:x_trace).wont_equal nil
       xtrace = response.headers[:x_trace]
@@ -62,26 +71,35 @@ if RUBY_VERSION >= '1.9.3'
       response = nil
 
       Oboe::API.start_trace('rest_client_test') do
-        response = RestClient.get 'http://www.appneta.com/products/traceview?a=1'
+        response = RestClient.get 'http://www.appneta.com/products/traceview/?a=1'
       end
 
       traces = get_all_traces
-      traces.count.must_equal 4
+      traces.count.must_equal 7
 
       validate_outer_layers(traces, 'rest_client_test')
 
       traces[1]['Layer'].must_equal 'rest-client'
       traces[1]['Label'].must_equal 'entry'
 
-      traces[2]['Layer'].must_equal 'rest-client'
-      traces[2]['Label'].must_equal 'exit'
-      traces[2]['IsService'].must_equal 1
-      traces[2]['RemoteProtocol'].must_equal 'HTTP'
-      traces[2]['RemoteHost'].must_equal 'www.appneta.com'
-      traces[2]['ServiceArg'].must_equal '/products/traceview?a=1'
-      traces[2]['HTTPMethod'].must_equal 'GET'
-      traces[2]['HTTPStatus'].must_equal 200
-      traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
+      traces[2]['Layer'].must_equal 'net-http'
+      traces[2]['Label'].must_equal 'entry'
+
+      traces[3]['Layer'].must_equal 'net-http'
+      traces[3]['Label'].must_equal 'info'
+      traces[3]['IsService'].must_equal 1
+      traces[3]['RemoteProtocol'].must_equal 'HTTP'
+      traces[3]['RemoteHost'].must_equal 'www.appneta.com'
+      traces[3]['ServiceArg'].must_equal '/products/traceview/?a=1'
+      traces[3]['HTTPMethod'].must_equal 'GET'
+      traces[3]['HTTPStatus'].must_equal "200"
+      traces[3].key?('Backtrace').must_equal Oboe::Config[:nethttp][:collect_backtraces]
+
+      traces[4]['Layer'].must_equal 'net-http'
+      traces[4]['Label'].must_equal 'exit'
+
+      traces[5]['Layer'].must_equal 'rest-client'
+      traces[5]['Label'].must_equal 'exit'
     end
 
     it 'should trace a raw POST request' do
@@ -92,25 +110,70 @@ if RUBY_VERSION >= '1.9.3'
       end
 
       traces = get_all_traces
-      traces.count.must_equal 4
+      traces.count.must_equal 7
 
       validate_outer_layers(traces, 'rest_client_test')
 
       traces[1]['Layer'].must_equal 'rest-client'
       traces[1]['Label'].must_equal 'entry'
 
-      traces[2]['Layer'].must_equal 'rest-client'
-      traces[2]['Label'].must_equal 'exit'
-      traces[2]['IsService'].must_equal 1
-      traces[2]['RemoteProtocol'].must_equal 'HTTP'
-      traces[2]['RemoteHost'].must_equal 'www.appneta.com'
-      traces[2]['ServiceArg'].must_equal '/'
-      traces[2]['HTTPMethod'].must_equal 'POST'
-      traces[2]['HTTPStatus'].must_equal 200
-      traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
+      traces[2]['Layer'].must_equal 'net-http'
+      traces[2]['Label'].must_equal 'entry'
+
+      traces[3]['Layer'].must_equal 'net-http'
+      traces[3]['Label'].must_equal 'info'
+      traces[3]['IsService'].must_equal 1
+      traces[3]['RemoteProtocol'].must_equal 'HTTP'
+      traces[3]['RemoteHost'].must_equal 'www.appneta.com'
+      traces[3]['ServiceArg'].must_equal '/'
+      traces[3]['HTTPMethod'].must_equal 'POST'
+      traces[3]['HTTPStatus'].must_equal "200"
+      traces[3].key?('Backtrace').must_equal Oboe::Config[:nethttp][:collect_backtraces]
+
+      traces[4]['Layer'].must_equal 'net-http'
+      traces[4]['Label'].must_equal 'exit'
+
+      traces[5]['Layer'].must_equal 'rest-client'
+      traces[5]['Label'].must_equal 'exit'
     end
 
     it 'should trace a ActiveResource style GET request' do
+      response = nil
+
+      Oboe::API.start_trace('rest_client_test') do
+        resource = RestClient::Resource.new 'http://www.appneta.com/products/traceview/?a=1'
+        response = resource.get
+      end
+
+      traces = get_all_traces
+      traces.count.must_equal 7
+
+      validate_outer_layers(traces, 'rest_client_test')
+
+      traces[1]['Layer'].must_equal 'rest-client'
+      traces[1]['Label'].must_equal 'entry'
+
+      traces[2]['Layer'].must_equal 'net-http'
+      traces[2]['Label'].must_equal 'entry'
+
+      traces[3]['Layer'].must_equal 'net-http'
+      traces[3]['Label'].must_equal 'info'
+      traces[3]['IsService'].must_equal 1
+      traces[3]['RemoteProtocol'].must_equal 'HTTP'
+      traces[3]['RemoteHost'].must_equal 'www.appneta.com'
+      traces[3]['ServiceArg'].must_equal '/products/traceview/?a=1'
+      traces[3]['HTTPMethod'].must_equal 'GET'
+      traces[3]['HTTPStatus'].must_equal "200"
+      traces[3].key?('Backtrace').must_equal Oboe::Config[:nethttp][:collect_backtraces]
+
+      traces[4]['Layer'].must_equal 'net-http'
+      traces[4]['Label'].must_equal 'exit'
+
+      traces[5]['Layer'].must_equal 'rest-client'
+      traces[5]['Label'].must_equal 'exit'
+    end
+
+    it 'should trace requests with redirects' do
       response = nil
 
       Oboe::API.start_trace('rest_client_test') do
@@ -119,22 +182,53 @@ if RUBY_VERSION >= '1.9.3'
       end
 
       traces = get_all_traces
-      traces.count.must_equal 4
+      traces.count.must_equal 12
 
       validate_outer_layers(traces, 'rest_client_test')
 
       traces[1]['Layer'].must_equal 'rest-client'
       traces[1]['Label'].must_equal 'entry'
 
-      traces[2]['Layer'].must_equal 'rest-client'
-      traces[2]['Label'].must_equal 'exit'
-      traces[2]['IsService'].must_equal 1
-      traces[2]['RemoteProtocol'].must_equal 'HTTP'
-      traces[2]['RemoteHost'].must_equal 'www.appneta.com'
-      traces[2]['ServiceArg'].must_equal '/products/traceview?a=1'
-      traces[2]['HTTPMethod'].must_equal 'GET'
-      traces[2]['HTTPStatus'].must_equal 200
-      traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
+      traces[2]['Layer'].must_equal 'net-http'
+      traces[2]['Label'].must_equal 'entry'
+
+      traces[3]['Layer'].must_equal 'net-http'
+      traces[3]['Label'].must_equal 'info'
+      traces[3]['IsService'].must_equal 1
+      traces[3]['RemoteProtocol'].must_equal 'HTTP'
+      traces[3]['RemoteHost'].must_equal 'www.appneta.com'
+      traces[3]['ServiceArg'].must_equal '/products/traceview?a=1'
+      traces[3]['HTTPMethod'].must_equal 'GET'
+      traces[3]['HTTPStatus'].must_equal "301"
+      traces[3].key?('Backtrace').must_equal Oboe::Config[:nethttp][:collect_backtraces]
+
+      traces[4]['Layer'].must_equal 'net-http'
+      traces[4]['Label'].must_equal 'exit'
+
+      traces[5]['Layer'].must_equal 'rest-client'
+      traces[5]['Label'].must_equal 'entry'
+
+      traces[6]['Layer'].must_equal 'net-http'
+      traces[6]['Label'].must_equal 'entry'
+
+      traces[7]['Layer'].must_equal 'net-http'
+      traces[7]['Label'].must_equal 'info'
+      traces[7]['IsService'].must_equal 1
+      traces[7]['RemoteProtocol'].must_equal 'HTTP'
+      traces[7]['RemoteHost'].must_equal 'www.appneta.com'
+      traces[7]['ServiceArg'].must_equal '/products/traceview/?a=1'
+      traces[7]['HTTPMethod'].must_equal 'GET'
+      traces[7]['HTTPStatus'].must_equal "200"
+      traces[7].key?('Backtrace').must_equal Oboe::Config[:nethttp][:collect_backtraces]
+
+      traces[8]['Layer'].must_equal 'net-http'
+      traces[8]['Label'].must_equal 'exit'
+
+      traces[9]['Layer'].must_equal 'rest-client'
+      traces[9]['Label'].must_equal 'exit'
+
+      traces[10]['Layer'].must_equal 'rest-client'
+      traces[10]['Label'].must_equal 'exit'
     end
 
     it 'should trace and capture raised exceptions' do
@@ -161,17 +255,10 @@ if RUBY_VERSION >= '1.9.3'
       traces[2]['Label'].must_equal 'error'
       traces[2]['ErrorClass'].must_equal 'SocketError'
       traces[2].key?('ErrorMsg').must_equal true
-      traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
+      traces[2].key?('Backtrace').must_equal true
 
       traces[3]['Layer'].must_equal 'rest-client'
       traces[3]['Label'].must_equal 'exit'
-      traces[3]['IsService'].must_equal 1
-      traces[3]['RemoteProtocol'].must_equal 'HTTP'
-      traces[3]['RemoteHost'].must_equal 's6KTgaz7636z'
-      traces[3]['ServiceArg'].must_equal '/resource'
-      traces[3]['HTTPMethod'].must_equal 'GET'
-      traces[3].key?('HTTPStatus').must_equal false
-      traces[3].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
     end
 
     it 'should obey :collect_backtraces setting when true' do

--- a/test/instrumentation/rest-client_test.rb
+++ b/test/instrumentation/rest-client_test.rb
@@ -160,7 +160,7 @@ if RUBY_VERSION >= '1.9.3'
       traces[2]['Layer'].must_equal 'rest-client'
       traces[2]['Label'].must_equal 'error'
       traces[2]['ErrorClass'].must_equal 'SocketError'
-      traces[2]['ErrorMsg'].must_equal "getaddrinfo: Name or service not known"
+      traces[2].key?('ErrorMsg').must_equal true
       traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
 
       traces[3]['Layer'].must_equal 'rest-client'

--- a/test/instrumentation/rest-client_test.rb
+++ b/test/instrumentation/rest-client_test.rb
@@ -1,0 +1,100 @@
+require 'minitest_helper'
+
+describe Oboe::Inst::RestClientRequest do
+  before do
+    clear_all_traces
+    @collect_backtraces = Oboe::Config[:rest_client][:collect_backtraces]
+  end
+
+  after do
+    Oboe::Config[:rest_client][:collect_backtraces] = @collect_backtraces
+  end
+
+  it 'RestClient should be defined and ready' do
+    defined?(::RestClient).wont_match nil
+  end
+
+  it 'RestClient should have oboe methods defined' do
+    [ :execute_with_oboe ].each do |m|
+      ::RestClient::Request.method_defined?(m).must_equal true
+    end
+  end
+
+  it "should trace a rest-client request to an instr'd app" do
+    response = nil
+
+    Oboe::API.start_trace('rest_client_test') do
+      response = RestClient.get 'http://gameface.in/gamers'
+    end
+
+    traces = get_all_traces
+    traces.count.must_equal 4
+
+    validate_outer_layers(traces, 'rest_client_test')
+
+    traces[1]['Layer'].must_equal 'rest-client'
+    traces[1]['Label'].must_equal 'entry'
+
+    traces[2]['Layer'].must_equal 'rest-client'
+    traces[2]['Label'].must_equal 'exit'
+    traces[2]['IsService'].must_equal 1
+    traces[2]['RemoteProtocol'].must_equal 'HTTP'
+    traces[2]['RemoteHost'].must_equal 'gameface.in'
+    traces[2]['ServiceArg'].must_equal '/gamers'
+    traces[2]['HTTPMethod'].must_equal 'GET'
+    traces[2]['HTTPStatus'].must_equal 200
+    traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
+
+    response.headers.key?(:x_trace).wont_equal nil
+    xtrace = response.headers[:x_trace]
+    Oboe::XTrace.valid?(xtrace).must_equal true
+  end
+
+  it 'should trace a rest-client GET request' do
+    reponse = nil
+
+    Oboe::API.start_trace('rest_client_test') do
+      response = RestClient.get 'http://www.appneta.com/products/traceview?a=1'
+    end
+
+    traces = get_all_traces
+    traces.count.must_equal 4
+
+    validate_outer_layers(traces, 'rest_client_test')
+
+    traces[1]['Layer'].must_equal 'rest-client'
+    traces[1]['Label'].must_equal 'entry'
+
+    traces[2]['Layer'].must_equal 'rest-client'
+    traces[2]['Label'].must_equal 'exit'
+    traces[2]['IsService'].must_equal 1
+    traces[2]['RemoteProtocol'].must_equal 'HTTP'
+    traces[2]['RemoteHost'].must_equal 'www.appneta.com'
+    traces[2]['ServiceArg'].must_equal '/products/traceview?a=1'
+    traces[2]['HTTPMethod'].must_equal 'GET'
+    traces[2]['HTTPStatus'].must_equal 200
+    traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
+  end
+
+  it 'should obey :collect_backtraces setting when true' do
+    Oboe::Config[:rest_client][:collect_backtraces] = true
+
+    Oboe::API.start_trace('rest_client_test') do
+      RestClient.get('http://www.appneta.com', {:a => 1})
+    end
+
+    traces = get_all_traces
+    layer_has_key(traces, 'rest-client', 'Backtrace')
+  end
+
+  it 'should obey :collect_backtraces setting when false' do
+    Oboe::Config[:rest_client][:collect_backtraces] = false
+
+    Oboe::API.start_trace('rest_client_test') do
+      RestClient.get('http://www.appneta.com', {:a => 1})
+    end
+
+    traces = get_all_traces
+    layer_doesnt_have_key(traces, 'rest-client', 'Backtrace')
+  end
+end

--- a/test/instrumentation/rest-client_test.rb
+++ b/test/instrumentation/rest-client_test.rb
@@ -21,6 +21,13 @@ if RUBY_VERSION >= '1.9.3'
       end
     end
 
+    it "should report rest-client version in __Init" do
+      init_kvs = ::Oboe::Util.build_init_report
+
+      init_kvs.key?('Ruby.RestClient.Version').must_equal true
+      init_kvs['Ruby.RestClient.Version'].must_equal "RestClient-#{::RestClient::VERSION}"
+    end
+
     it "should trace a request to an instr'd app" do
       response = nil
 

--- a/test/instrumentation/rest-client_test.rb
+++ b/test/instrumentation/rest-client_test.rb
@@ -38,6 +38,9 @@ if RUBY_VERSION >= '1.9.3'
       traces = get_all_traces
       traces.count.must_equal 7
 
+      # FIXME: We need to switch from making external calls to an internal test
+      # stack instead so we can validate cross-app traces.
+      # valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rest_client_test')
 
       traces[1]['Layer'].must_equal 'rest-client'
@@ -77,6 +80,9 @@ if RUBY_VERSION >= '1.9.3'
       traces = get_all_traces
       traces.count.must_equal 7
 
+      # FIXME: We need to switch from making external calls to an internal test
+      # stack instead so we can validate cross-app traces.
+      # valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rest_client_test')
 
       traces[1]['Layer'].must_equal 'rest-client'
@@ -112,6 +118,9 @@ if RUBY_VERSION >= '1.9.3'
       traces = get_all_traces
       traces.count.must_equal 7
 
+      # FIXME: We need to switch from making external calls to an internal test
+      # stack instead so we can validate cross-app traces.
+      # valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rest_client_test')
 
       traces[1]['Layer'].must_equal 'rest-client'
@@ -148,6 +157,9 @@ if RUBY_VERSION >= '1.9.3'
       traces = get_all_traces
       traces.count.must_equal 7
 
+      # FIXME: We need to switch from making external calls to an internal test
+      # stack instead so we can validate cross-app traces.
+      # valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rest_client_test')
 
       traces[1]['Layer'].must_equal 'rest-client'
@@ -184,6 +196,9 @@ if RUBY_VERSION >= '1.9.3'
       traces = get_all_traces
       traces.count.must_equal 12
 
+      # FIXME: We need to switch from making external calls to an internal test
+      # stack instead so we can validate cross-app traces.
+      # valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rest_client_test')
 
       traces[1]['Layer'].must_equal 'rest-client'
@@ -246,6 +261,7 @@ if RUBY_VERSION >= '1.9.3'
       traces = get_all_traces
       traces.count.must_equal 5
 
+      valid_edges?(traces).must_equal true
       validate_outer_layers(traces, 'rest_client_test')
 
       traces[1]['Layer'].must_equal 'rest-client'

--- a/test/instrumentation/rest-client_test.rb
+++ b/test/instrumentation/rest-client_test.rb
@@ -1,190 +1,192 @@
 require 'minitest_helper'
 
-describe Oboe::Inst::RestClientRequest do
-  before do
-    clear_all_traces
-    @collect_backtraces = Oboe::Config[:rest_client][:collect_backtraces]
-  end
-
-  after do
-    Oboe::Config[:rest_client][:collect_backtraces] = @collect_backtraces
-  end
-
-  it 'RestClient should be defined and ready' do
-    defined?(::RestClient).wont_match nil
-  end
-
-  it 'RestClient should have oboe methods defined' do
-    [ :execute_with_oboe ].each do |m|
-      ::RestClient::Request.method_defined?(m).must_equal true
-    end
-  end
-
-  it "should trace a request to an instr'd app" do
-    response = nil
-
-    Oboe::API.start_trace('rest_client_test') do
-      response = RestClient.get 'http://gameface.in/gamers'
+if RUBY_VERSION >= '1.9.3'
+  describe Oboe::Inst::RestClientRequest do
+    before do
+      clear_all_traces
+      @collect_backtraces = Oboe::Config[:rest_client][:collect_backtraces]
     end
 
-    traces = get_all_traces
-    traces.count.must_equal 4
-
-    validate_outer_layers(traces, 'rest_client_test')
-
-    traces[1]['Layer'].must_equal 'rest-client'
-    traces[1]['Label'].must_equal 'entry'
-
-    traces[2]['Layer'].must_equal 'rest-client'
-    traces[2]['Label'].must_equal 'exit'
-    traces[2]['IsService'].must_equal 1
-    traces[2]['RemoteProtocol'].must_equal 'HTTP'
-    traces[2]['RemoteHost'].must_equal 'gameface.in'
-    traces[2]['ServiceArg'].must_equal '/gamers'
-    traces[2]['HTTPMethod'].must_equal 'GET'
-    traces[2]['HTTPStatus'].must_equal 200
-    traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
-
-    response.headers.key?(:x_trace).wont_equal nil
-    xtrace = response.headers[:x_trace]
-    Oboe::XTrace.valid?(xtrace).must_equal true
-  end
-
-  it 'should trace a raw GET request' do
-    response = nil
-
-    Oboe::API.start_trace('rest_client_test') do
-      response = RestClient.get 'http://www.appneta.com/products/traceview?a=1'
+    after do
+      Oboe::Config[:rest_client][:collect_backtraces] = @collect_backtraces
     end
 
-    traces = get_all_traces
-    traces.count.must_equal 4
-
-    validate_outer_layers(traces, 'rest_client_test')
-
-    traces[1]['Layer'].must_equal 'rest-client'
-    traces[1]['Label'].must_equal 'entry'
-
-    traces[2]['Layer'].must_equal 'rest-client'
-    traces[2]['Label'].must_equal 'exit'
-    traces[2]['IsService'].must_equal 1
-    traces[2]['RemoteProtocol'].must_equal 'HTTP'
-    traces[2]['RemoteHost'].must_equal 'www.appneta.com'
-    traces[2]['ServiceArg'].must_equal '/products/traceview?a=1'
-    traces[2]['HTTPMethod'].must_equal 'GET'
-    traces[2]['HTTPStatus'].must_equal 200
-    traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
-  end
-
-  it 'should trace a raw POST request' do
-    response = nil
-
-    Oboe::API.start_trace('rest_client_test') do
-      response = RestClient.post 'http://www.appneta.com/', :param1 => 'one', :nested => { :param2 => 'two' }
+    it 'RestClient should be defined and ready' do
+      defined?(::RestClient).wont_match nil
     end
 
-    traces = get_all_traces
-    traces.count.must_equal 4
-
-    validate_outer_layers(traces, 'rest_client_test')
-
-    traces[1]['Layer'].must_equal 'rest-client'
-    traces[1]['Label'].must_equal 'entry'
-
-    traces[2]['Layer'].must_equal 'rest-client'
-    traces[2]['Label'].must_equal 'exit'
-    traces[2]['IsService'].must_equal 1
-    traces[2]['RemoteProtocol'].must_equal 'HTTP'
-    traces[2]['RemoteHost'].must_equal 'www.appneta.com'
-    traces[2]['ServiceArg'].must_equal '/'
-    traces[2]['HTTPMethod'].must_equal 'POST'
-    traces[2]['HTTPStatus'].must_equal 200
-    traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
-  end
-
-  it 'should trace a ActiveResource style GET request' do
-    response = nil
-
-    Oboe::API.start_trace('rest_client_test') do
-      resource = RestClient::Resource.new 'http://www.appneta.com/products/traceview?a=1'
-      response = resource.get
-    end
-
-    traces = get_all_traces
-    traces.count.must_equal 4
-
-    validate_outer_layers(traces, 'rest_client_test')
-
-    traces[1]['Layer'].must_equal 'rest-client'
-    traces[1]['Label'].must_equal 'entry'
-
-    traces[2]['Layer'].must_equal 'rest-client'
-    traces[2]['Label'].must_equal 'exit'
-    traces[2]['IsService'].must_equal 1
-    traces[2]['RemoteProtocol'].must_equal 'HTTP'
-    traces[2]['RemoteHost'].must_equal 'www.appneta.com'
-    traces[2]['ServiceArg'].must_equal '/products/traceview?a=1'
-    traces[2]['HTTPMethod'].must_equal 'GET'
-    traces[2]['HTTPStatus'].must_equal 200
-    traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
-  end
-
-  it 'should trace and capture raised exceptions' do
-    response = nil
-
-    Oboe::API.start_trace('rest_client_test') do
-      begin
-        RestClient.get 'http://s6KTgaz7636z/resource'
-      rescue
-        # We want an exception to be raised.  Just don't raise
-        # it beyond this point.
+    it 'RestClient should have oboe methods defined' do
+      [ :execute_with_oboe ].each do |m|
+        ::RestClient::Request.method_defined?(m).must_equal true
       end
     end
 
-    traces = get_all_traces
-    traces.count.must_equal 5
+    it "should trace a request to an instr'd app" do
+      response = nil
 
-    validate_outer_layers(traces, 'rest_client_test')
+      Oboe::API.start_trace('rest_client_test') do
+        response = RestClient.get 'http://gameface.in/gamers'
+      end
 
-    traces[1]['Layer'].must_equal 'rest-client'
-    traces[1]['Label'].must_equal 'entry'
+      traces = get_all_traces
+      traces.count.must_equal 4
 
-    traces[2]['Layer'].must_equal 'rest-client'
-    traces[2]['Label'].must_equal 'error'
-    traces[2]['ErrorClass'].must_equal 'SocketError'
-    traces[2]['ErrorMsg'].must_equal "getaddrinfo: Name or service not known"
-    traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
+      validate_outer_layers(traces, 'rest_client_test')
 
-    traces[3]['Layer'].must_equal 'rest-client'
-    traces[3]['Label'].must_equal 'exit'
-    traces[3]['IsService'].must_equal 1
-    traces[3]['RemoteProtocol'].must_equal 'HTTP'
-    traces[3]['RemoteHost'].must_equal 's6KTgaz7636z'
-    traces[3]['ServiceArg'].must_equal '/resource'
-    traces[3]['HTTPMethod'].must_equal 'GET'
-    traces[3].key?('HTTPStatus').must_equal false
-    traces[3].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
-  end
+      traces[1]['Layer'].must_equal 'rest-client'
+      traces[1]['Label'].must_equal 'entry'
 
-  it 'should obey :collect_backtraces setting when true' do
-    Oboe::Config[:rest_client][:collect_backtraces] = true
+      traces[2]['Layer'].must_equal 'rest-client'
+      traces[2]['Label'].must_equal 'exit'
+      traces[2]['IsService'].must_equal 1
+      traces[2]['RemoteProtocol'].must_equal 'HTTP'
+      traces[2]['RemoteHost'].must_equal 'gameface.in'
+      traces[2]['ServiceArg'].must_equal '/gamers'
+      traces[2]['HTTPMethod'].must_equal 'GET'
+      traces[2]['HTTPStatus'].must_equal 200
+      traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
 
-    Oboe::API.start_trace('rest_client_test') do
-      RestClient.get('http://www.appneta.com', {:a => 1})
+      response.headers.key?(:x_trace).wont_equal nil
+      xtrace = response.headers[:x_trace]
+      Oboe::XTrace.valid?(xtrace).must_equal true
     end
 
-    traces = get_all_traces
-    layer_has_key(traces, 'rest-client', 'Backtrace')
-  end
+    it 'should trace a raw GET request' do
+      response = nil
 
-  it 'should obey :collect_backtraces setting when false' do
-    Oboe::Config[:rest_client][:collect_backtraces] = false
+      Oboe::API.start_trace('rest_client_test') do
+        response = RestClient.get 'http://www.appneta.com/products/traceview?a=1'
+      end
 
-    Oboe::API.start_trace('rest_client_test') do
-      RestClient.get('http://www.appneta.com', {:a => 1})
+      traces = get_all_traces
+      traces.count.must_equal 4
+
+      validate_outer_layers(traces, 'rest_client_test')
+
+      traces[1]['Layer'].must_equal 'rest-client'
+      traces[1]['Label'].must_equal 'entry'
+
+      traces[2]['Layer'].must_equal 'rest-client'
+      traces[2]['Label'].must_equal 'exit'
+      traces[2]['IsService'].must_equal 1
+      traces[2]['RemoteProtocol'].must_equal 'HTTP'
+      traces[2]['RemoteHost'].must_equal 'www.appneta.com'
+      traces[2]['ServiceArg'].must_equal '/products/traceview?a=1'
+      traces[2]['HTTPMethod'].must_equal 'GET'
+      traces[2]['HTTPStatus'].must_equal 200
+      traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
     end
 
-    traces = get_all_traces
-    layer_doesnt_have_key(traces, 'rest-client', 'Backtrace')
+    it 'should trace a raw POST request' do
+      response = nil
+
+      Oboe::API.start_trace('rest_client_test') do
+        response = RestClient.post 'http://www.appneta.com/', :param1 => 'one', :nested => { :param2 => 'two' }
+      end
+
+      traces = get_all_traces
+      traces.count.must_equal 4
+
+      validate_outer_layers(traces, 'rest_client_test')
+
+      traces[1]['Layer'].must_equal 'rest-client'
+      traces[1]['Label'].must_equal 'entry'
+
+      traces[2]['Layer'].must_equal 'rest-client'
+      traces[2]['Label'].must_equal 'exit'
+      traces[2]['IsService'].must_equal 1
+      traces[2]['RemoteProtocol'].must_equal 'HTTP'
+      traces[2]['RemoteHost'].must_equal 'www.appneta.com'
+      traces[2]['ServiceArg'].must_equal '/'
+      traces[2]['HTTPMethod'].must_equal 'POST'
+      traces[2]['HTTPStatus'].must_equal 200
+      traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
+    end
+
+    it 'should trace a ActiveResource style GET request' do
+      response = nil
+
+      Oboe::API.start_trace('rest_client_test') do
+        resource = RestClient::Resource.new 'http://www.appneta.com/products/traceview?a=1'
+        response = resource.get
+      end
+
+      traces = get_all_traces
+      traces.count.must_equal 4
+
+      validate_outer_layers(traces, 'rest_client_test')
+
+      traces[1]['Layer'].must_equal 'rest-client'
+      traces[1]['Label'].must_equal 'entry'
+
+      traces[2]['Layer'].must_equal 'rest-client'
+      traces[2]['Label'].must_equal 'exit'
+      traces[2]['IsService'].must_equal 1
+      traces[2]['RemoteProtocol'].must_equal 'HTTP'
+      traces[2]['RemoteHost'].must_equal 'www.appneta.com'
+      traces[2]['ServiceArg'].must_equal '/products/traceview?a=1'
+      traces[2]['HTTPMethod'].must_equal 'GET'
+      traces[2]['HTTPStatus'].must_equal 200
+      traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
+    end
+
+    it 'should trace and capture raised exceptions' do
+      response = nil
+
+      Oboe::API.start_trace('rest_client_test') do
+        begin
+          RestClient.get 'http://s6KTgaz7636z/resource'
+        rescue
+          # We want an exception to be raised.  Just don't raise
+          # it beyond this point.
+        end
+      end
+
+      traces = get_all_traces
+      traces.count.must_equal 5
+
+      validate_outer_layers(traces, 'rest_client_test')
+
+      traces[1]['Layer'].must_equal 'rest-client'
+      traces[1]['Label'].must_equal 'entry'
+
+      traces[2]['Layer'].must_equal 'rest-client'
+      traces[2]['Label'].must_equal 'error'
+      traces[2]['ErrorClass'].must_equal 'SocketError'
+      traces[2]['ErrorMsg'].must_equal "getaddrinfo: Name or service not known"
+      traces[2].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
+
+      traces[3]['Layer'].must_equal 'rest-client'
+      traces[3]['Label'].must_equal 'exit'
+      traces[3]['IsService'].must_equal 1
+      traces[3]['RemoteProtocol'].must_equal 'HTTP'
+      traces[3]['RemoteHost'].must_equal 's6KTgaz7636z'
+      traces[3]['ServiceArg'].must_equal '/resource'
+      traces[3]['HTTPMethod'].must_equal 'GET'
+      traces[3].key?('HTTPStatus').must_equal false
+      traces[3].key?('Backtrace').must_equal Oboe::Config[:rest_client][:collect_backtraces]
+    end
+
+    it 'should obey :collect_backtraces setting when true' do
+      Oboe::Config[:rest_client][:collect_backtraces] = true
+
+      Oboe::API.start_trace('rest_client_test') do
+        RestClient.get('http://www.appneta.com', {:a => 1})
+      end
+
+      traces = get_all_traces
+      layer_has_key(traces, 'rest-client', 'Backtrace')
+    end
+
+    it 'should obey :collect_backtraces setting when false' do
+      Oboe::Config[:rest_client][:collect_backtraces] = false
+
+      Oboe::API.start_trace('rest_client_test') do
+        RestClient.get('http://www.appneta.com', {:a => 1})
+      end
+
+      traces = get_all_traces
+      layer_doesnt_have_key(traces, 'rest-client', 'Backtrace')
+    end
   end
 end

--- a/test/instrumentation/typhoeus_test.rb
+++ b/test/instrumentation/typhoeus_test.rb
@@ -208,9 +208,6 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
     validate_outer_layers(traces, 'outer')
 
-    #require 'byebug'
-    #debugger
-
     traces[2]['Layer'].must_equal 'rack'
     traces[2]['Label'].must_equal 'entry'
     traces[4]['Layer'].must_equal 'rack'

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -81,6 +81,41 @@ def validate_event_keys(event, kvs)
 end
 
 ##
+# has_edge?
+#
+# Searches the array of <tt>traces</tt> for
+# <tt>edge</tt>
+#
+def has_edge?(edge, traces)
+  traces.each do |t|
+    if Oboe::XTrace.edge_id(t["X-Trace"]) == edge
+      return true
+    end
+  end
+  Oboe.logger.debug "[oboe/debug] edge #{edge} not found in traces."
+  false
+end
+
+##
+# valid_edges?
+#
+# Runs through the array of <tt>traces</tt> to validate
+# that all edges connect.
+#
+# Not that this won't work for external cross-app tracing
+# since we won't have those remote traces to validate
+# against.
+#
+def valid_edges?(traces)
+  traces.reverse.each do  |t|
+    if t.key?("Edge")
+      return false unless has_edge?(t["Edge"], traces)
+    end
+  end
+  true
+end
+
+##
 # layer_has_key
 #
 # Checks an array of trace events if a specific layer (regardless of event type)

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -23,7 +23,7 @@ describe Oboe::Config do
     instrumentation = Oboe::Config.instrumentation_list
 
     # Verify the number of individual instrumentations
-    instrumentation.count.must_equal 18
+    instrumentation.count.must_equal 19
 
     Oboe::Config[:action_controller][:enabled].must_equal true
     Oboe::Config[:action_view][:enabled].must_equal true
@@ -41,6 +41,9 @@ describe Oboe::Config do
     Oboe::Config[:rack][:enabled].must_equal true
     Oboe::Config[:redis][:enabled].must_equal true
     Oboe::Config[:resque][:enabled].must_equal true
+    Oboe::Config[:rest_client][:enabled].must_equal true
+    Oboe::Config[:sequel][:enabled].must_equal true
+    Oboe::Config[:typhoeus][:enabled].must_equal true
 
     Oboe::Config[:action_controller][:log_args].must_equal true
     Oboe::Config[:action_view][:log_args].must_equal true
@@ -58,6 +61,9 @@ describe Oboe::Config do
     Oboe::Config[:rack][:log_args].must_equal true
     Oboe::Config[:redis][:log_args].must_equal true
     Oboe::Config[:resque][:log_args].must_equal true
+    Oboe::Config[:rest_client][:log_args].must_equal true
+    Oboe::Config[:sequel][:log_args].must_equal true
+    Oboe::Config[:typhoeus][:log_args].must_equal true
 
     Oboe::Config[:resque][:link_workers].must_equal false
     Oboe::Config[:blacklist].is_a?(Array).must_equal true


### PR DESCRIPTION
It time to instrument [rest-client](https://rubygems.org/gems/rest-client)!

https://github.com/rest-client/rest-client

- [x] Add rest-client to `Oboe::Config` and update support tests
- [x] Core instrumentation
- [x] Add tests against Raw URL requests
- [x] Add tests against ActiveResource-Style requests
- [x] Add tests for request exceptions
- [x] Backtest to validate supported versions
- [x] Update tests to follow most recent changes
- [x] Benchmark instrumentation against vanilla

Post-release:
- [ ] Add rest-client to support matrix
