### PR TITLE
Rails Instrumentation should respect top-level rescue handlers

### DIFF
--- a/lib/oboe/config.rb
+++ b/lib/oboe/config.rb
@@ -101,6 +101,12 @@ module Oboe
       @@config[:dnt_regexp] = "\.(jpg|jpeg|gif|png|ico|css|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|js|flv|swf|ttf|woff|svg|less)$"
       @@config[:dnt_opts]   = Regexp::IGNORECASE
 
+      # In Rails, raised exceptions with rescue handlers via
+      # <tt>rescue_from</tt> are not reported to the TraceView
+      # dashboard by default.  Setting this value to true will
+      # report all raised exception regardless.
+      @@config[:report_rescued_errors] = false
+
       if ENV.key?('OPENSHIFT_TRACEVIEW_TLYZER_IP')
         # We're running on OpenShift
         @@config[:tracing_mode] = 'always'

--- a/lib/oboe/frameworks/rails/inst/action_controller.rb
+++ b/lib/oboe/frameworks/rails/inst/action_controller.rb
@@ -81,9 +81,14 @@ module Oboe
       end
 
       def process_with_oboe(*args)
-        Oboe::API.trace('rails', {}) do
-          process_without_oboe *args
-        end
+        Oboe::API.log_entry('rails')
+        process_without_oboe *args
+
+      rescue Exception => e
+        Oboe::API.log_exception(nil, e) if log_rails_error?(e)
+        raise
+      ensure
+        Oboe::API.log_exit('rails')
       end
 
       def process_action_with_oboe(*args)
@@ -125,9 +130,15 @@ module Oboe
           :Controller   => self.class.name,
           :Action       => self.action_name,
         }
-        Oboe::API.trace('rails', report_kvs) do
-          process_action_without_oboe(method_name, *args)
-        end
+
+        Oboe::API.log_entry('rails')
+        process_action_without_oboe(method_name, *args)
+
+      rescue Exception => e
+        Oboe::API.log_exception(nil, e) if log_rails_error?(e)
+        raise
+      ensure
+        Oboe::API.log_exit('rails')
       end
     end
   end

--- a/lib/oboe/frameworks/rails/inst/action_controller.rb
+++ b/lib/oboe/frameworks/rails/inst/action_controller.rb
@@ -3,7 +3,75 @@
 
 module Oboe
   module Inst
-    module Rails3ActionController
+    #
+    # RailsBase
+    #
+    # This module contains the instrumentation code common to
+    # many Rails versions.
+    #
+    module RailsBase
+      #
+      # has_handler?
+      #
+      # Determins if <tt>exception</tt> has a registered
+      # handler via <tt>rescue_from</tt>
+      #
+      def has_handler?(exception)
+        # Don't log exceptions if they have a rescue handler set
+        has_handler = false
+        rescue_handlers.detect { | klass_name, handler |
+          # Rescue handlers can be specified as strings or constant names
+          klass = self.class.const_get(klass_name) rescue nil
+          klass ||= klass_name.constantize rescue nil
+          has_handler = exception.is_a?(klass) if klass
+        }
+        has_handler
+      end
+
+      #
+      # log_rails_error?
+      #
+      # Determins whether we should log a raised exception to the
+      # TraceView dashboard.  This is determined by whether the exception
+      # has a rescue handler setup and the value of
+      # Oboe::Config[:report_rescued_errors]
+      #
+      def log_rails_error?(exception)
+        has_handler = has_handler?(exception)
+
+        if !has_handler || (has_handler && Oboe::Config[:report_rescued_errors])
+          return true
+        end
+        false
+      end
+
+      #
+      # render_with_oboe
+      #
+      # Our render wrapper that just times and conditionally
+      # reports raised exceptions
+      #
+      def render_with_oboe(*args)
+        Oboe::API.log_entry('actionview')
+        render_without_oboe(*args)
+
+      rescue Exception => e
+        Oboe::API.log_exception(nil, e) if log_rails_error?(e)
+        raise
+      ensure
+        Oboe::API.log_exit('actionview')
+      end
+    end
+
+    #
+    # ActionController3
+    #
+    # This modules contains the instrumentation code specific
+    # to Rails v3
+    #
+    module ActionController3
+      include ::Oboe::Inst::RailsBase
+
       def self.included(base)
         base.class_eval do
           alias_method_chain :process, :oboe
@@ -31,15 +99,17 @@ module Oboe
         Oboe::API.log(nil, 'info', report_kvs)
         raise
       end
-
-      def render_with_oboe(*args)
-        Oboe::API.trace('actionview', {}) do
-          render_without_oboe *args
-        end
-      end
     end
 
-    module Rails4ActionController
+    #
+    # ActionController4
+    #
+    # This modules contains the instrumentation code specific
+    # to Rails v4
+    #
+    module ActionController4
+      include ::Oboe::Inst::RailsBase
+
       def self.included(base)
         base.class_eval do
           alias_method_chain :process_action, :oboe
@@ -59,25 +129,6 @@ module Oboe
           process_action_without_oboe(method_name, *args)
         end
       end
-
-      def render_with_oboe(*args)
-        Oboe::API.log_entry('actionview')
-        render_without_oboe(*args)
-
-      rescue StandardError => e
-        # Don't log exceptions if they have a rescue handler set
-        has_handler = false
-        rescue_handlers.detect { | klass_name, handler |
-          # Rescue handlers can be specified as strings or constant names
-          klass = self.class.const_get(klass_name) rescue nil
-          klass ||= klass_name.constantize rescue nil
-          has_handler = e.is_a?(klass) if klass
-        }
-        Oboe::API.log_exception(nil, e) unless has_handler
-        raise
-      ensure
-        Oboe::API.log_exit('actionview')
-      end
     end
   end
 end
@@ -86,13 +137,13 @@ if defined?(ActionController::Base) && Oboe::Config[:action_controller][:enabled
   if ::Rails::VERSION::MAJOR == 4
 
     class ActionController::Base
-      include Oboe::Inst::Rails4ActionController
+      include Oboe::Inst::ActionController4
     end
 
   elsif ::Rails::VERSION::MAJOR == 3
 
     class ActionController::Base
-      include Oboe::Inst::Rails3ActionController
+      include Oboe::Inst::ActionController3
     end
 
   elsif ::Rails::VERSION::MAJOR == 2

--- a/lib/oboe/frameworks/rails/inst/action_controller.rb
+++ b/lib/oboe/frameworks/rails/inst/action_controller.rb
@@ -26,6 +26,9 @@ module Oboe
           has_handler = exception.is_a?(klass) if klass
         }
         has_handler
+      rescue => e
+        Oboe.logger.debug "[oboe/debug] Error searching Rails handlers: #{e.message}"
+        return false
       end
 
       #
@@ -37,6 +40,10 @@ module Oboe
       # Oboe::Config[:report_rescued_errors]
       #
       def log_rails_error?(exception)
+        # As it's perculating up through the layers...  make sure that
+        # we only report it once.
+        return false if exception.instance_variable_get(:@oboe_logged)
+
         has_handler = has_handler?(exception)
 
         if !has_handler || (has_handler && Oboe::Config[:report_rescued_errors])

--- a/lib/rails/generators/oboe/templates/oboe_initializer.rb
+++ b/lib/rails/generators/oboe/templates/oboe_initializer.rb
@@ -21,20 +21,6 @@ if defined?(Oboe::Config)
   # Verbose output of instrumentation initialization
   # Oboe::Config[:verbose] = <%= @verbose %>
 
-  #
-  # Resque Options
-  #
-  # :link_workers - associates Resque enqueue operations with the jobs they queue by piggybacking
-  #                 an additional argument on the Redis queue that is stripped prior to job
-  #                 processing
-  #                 !!! Note: Make sure both the enqueue side and the Resque workers are instrumented
-  #                 before enabling this or jobs will fail !!!
-  #                 (Default: false)
-  # Oboe::Config[:resque][:link_workers] = false
-  #
-  # Set to true to disable Resque argument logging (Default: false)
-  # Oboe::Config[:resque][:log_args] = false
-
   # The oboe Ruby client has the ability to sanitize query literals
   # from SQL statements.  By default this is disabled.  Enable to
   # avoid collecting and reporting query literals to TraceView.
@@ -69,6 +55,17 @@ if defined?(Oboe::Config)
   # Oboe::Config[:dnt_opts]   = Regexp::IGNORECASE
 
   #
+  # Rails Exception Logging
+  #
+  # In Rails, raised exceptions with rescue handlers via
+  # <tt>rescue_from</tt> are not reported to the TraceView
+  # dashboard by default.  Setting this value to true will
+  # report all raised exception regardless.
+  #
+  # Oboe::Config[:report_rescued_errors] = false
+  #
+
+  #
   # Enabling/Disabling Instrumentation
   #
   # If you're having trouble with one of the instrumentation libraries, they
@@ -80,6 +77,7 @@ if defined?(Oboe::Config)
   # Oboe::Config[:action_view][:enabled] = true
   # Oboe::Config[:cassandra][:enabled] = true
   # Oboe::Config[:dalli][:enabled] = true
+  # Oboe::Config[:em_http_request][:enabled] = true
   # Oboe::Config[:faraday][:enabled] = true
   # Oboe::Config[:memcache][:enabled] = true
   # Oboe::Config[:memcached][:enabled] = true
@@ -88,7 +86,9 @@ if defined?(Oboe::Config)
   # Oboe::Config[:nethttp][:enabled] = true
   # Oboe::Config[:redis][:enabled] = true
   # Oboe::Config[:resque][:enabled] = true
-  # Oboe::Config[:em_http_request][:enabled] = true
+  # Oboe::Config[:sequel][:enabled] = true
+  # Oboe::Config[:typhoeus][:enabled] = true
+  #
 
   #
   # Enabling/Disabling Backtrace Collection
@@ -103,6 +103,7 @@ if defined?(Oboe::Config)
   # Oboe::Config[:action_view][:collect_backtraces] = true
   # Oboe::Config[:cassandra][:collect_backtraces] = true
   # Oboe::Config[:dalli][:collect_backtraces] = false
+  # Oboe::Config[:em_http_request][:collect_backtraces] = true
   # Oboe::Config[:faraday][:collect_backtraces] = false
   # Oboe::Config[:memcache][:collect_backtraces] = false
   # Oboe::Config[:memcached][:collect_backtraces] = false
@@ -111,7 +112,8 @@ if defined?(Oboe::Config)
   # Oboe::Config[:nethttp][:collect_backtraces] = true
   # Oboe::Config[:redis][:collect_backtraces] = false
   # Oboe::Config[:resque][:collect_backtraces] = true
-  # Oboe::Config[:em_http_request][:collect_backtraces] = true
+  # Oboe::Config[:sequel][:collect_backtraces] = true
+  # Oboe::Config[:typhoeus][:collect_backtraces] = false
   #
 
   #
@@ -123,4 +125,17 @@ if defined?(Oboe::Config)
   #     'index#ok' => true
   # }
 
+  #
+  # Resque Options
+  #
+  # :link_workers - associates Resque enqueue operations with the jobs they queue by piggybacking
+  #                 an additional argument on the Redis queue that is stripped prior to job
+  #                 processing
+  #                 !!! Note: Make sure both the enqueue side and the Resque workers are instrumented
+  #                 before enabling this or jobs will fail !!!
+  #                 (Default: false)
+  # Oboe::Config[:resque][:link_workers] = false
+  #
+  # Set to true to disable Resque argument logging (Default: false)
+  # Oboe::Config[:resque][:log_args] = false
 end


### PR DESCRIPTION
We currently report some errors even though they may have been captured by rescue_from in the Application controller.

- [x] Rails 4 rescue handler checking
- [x] Rails 3 rescue handler checking
- [x] Rails 2 rescue handler checking
- [x] Add config option to report all exceptions regardless
- [x] Tests, tests and more tests.

