### PR TITLE
Deploying custom instrumented Ruby code to environments without libraries

### DIFF
--- a/lib/oboe/ruby.rb
+++ b/lib/oboe/ruby.rb
@@ -19,8 +19,13 @@ module Oboe
       # will instead be detected at load time and initialization is
       # automatic.
       def load
-        Oboe::Loading.load_access_key
-        Oboe::Inst.load_instrumentation
+        # In case some apps call this manually, make sure
+        # that the gem is fully loaded and not in no-op
+        # mode (e.g. on unsupported platforms etc.)
+        if Oboe.loaded
+          Oboe::Loading.load_access_key
+          Oboe::Inst.load_instrumentation
+        end
       end
     end
   end


### PR DESCRIPTION
After instrumenting some custom code and then deploying to environments (like continuous integration servers), the following error is encountered. Can this error be avoided and any instrumentation in these environments be a no-op?

```
==============================================================
Missing TraceView libraries.  Tracing disabled.
See: http://bit.ly/1DaNOjw
==============================================================
/home/rof/cache/bundler/ruby/2.1.0/gems/oboe-2.7.15.1/lib/oboe/ruby.rb:23:in `load': uninitialized constant Oboe::Inst (NameError)
```