### PR TITLE
Instrument excon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,4 +52,7 @@ services:
 
 matrix:
   allow_failures:
+    # FIXME: Until the joboe test reporter supports cross thread
+    # event collection.
+    - rvm: jruby-19mode
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,13 @@ group :development, :test do
   gem 'minitest-reporters'
   gem 'rack-test'
   gem 'puma'
-  gem 'appraisal'
+  if RUBY_VERSION == '1.8.7'
+    gem 'i18n', '< 0.7.0'
+    gem 'activesupport', '< 4.0.5'
+    gem 'appraisal'
+  else
+    gem 'appraisal'
+  end
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,7 @@ group :development, :test do
   gem 'minitest-reporters'
   gem 'rack-test'
   gem 'puma'
-  if RUBY_VERSION > '1.8.7'
-    gem 'appraisal'
-  end
+  gem 'appraisal'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,10 @@ group :development, :test do
   gem 'minitest-reporters'
   gem 'rack-test'
   gem 'puma'
-  if RUBY_VERSION == '1.8.7'
+  if RUBY_VERSION < '1.9.3'
+    # i18n 0.7.0 dropped support for Ruby 1.9.2 and older.  ActiveSupport
+    # depends on i18n 0.7.0 since v 4.0.5.  For < 1.9.2 Ruby support, lock
+    # down to these versions to maintain functionality.
     gem 'i18n', '< 0.7.0'
     gem 'activesupport', '< 4.0.5'
     gem 'appraisal'

--- a/Gemfile
+++ b/Gemfile
@@ -59,12 +59,6 @@ if RUBY_VERSION >= '1.9'
   gem 'em-http-request'
 end
 
-# FIXME:Newer activesupport and i18n now require
-# ruby >= 1.9.3.  We limit their versions temporarily
-# until we figure out a better gem matrix for tests.
-gem "activesupport", "<= 4.0.4"
-gem "i18n", "< 0.7.0"
-
 unless defined?(JRUBY_VERSION)
   gem 'memcached', '1.7.2' if RUBY_VERSION < '2.0.0'
   gem 'bson_ext' # For Mongo, Yours Truly

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :development, :test do
   gem 'minitest', "5.5.1"
   gem 'minitest-reporters'
   gem 'rack-test'
+  gem 'thin'
   if RUBY_VERSION > '1.8.7'
     gem 'appraisal'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ group :development, :test do
   gem 'minitest', "5.5.1"
   gem 'minitest-reporters'
   gem 'rack-test'
-  gem 'thin'
+  gem 'puma'
   if RUBY_VERSION > '1.8.7'
     gem 'appraisal'
   end

--- a/Rakefile
+++ b/Rakefile
@@ -3,10 +3,7 @@
 require 'rubygems'
 require 'bundler/setup'
 require 'rake/testtask'
-
-if RUBY_VERSION > '1.8.7'
-  require 'appraisal'
-end
+require 'appraisal'
 
 Rake::TestTask.new do |t|
   t.libs << "test"

--- a/lib/oboe/config.rb
+++ b/lib/oboe/config.rb
@@ -12,9 +12,10 @@ module Oboe
     @@config = {}
 
     @@instrumentation = [:action_controller, :action_view, :active_record,
-                         :cassandra, :dalli, :em_http_request, :faraday, :grape, :nethttp,
-                         :memcached, :memcache, :mongo, :moped, :rack, :redis, :resque,
-                         :rest_client, :sequel, :typhoeus]
+                         :cassandra, :dalli, :em_http_request, :excon, :faraday,
+                         :grape, :nethttp, :memcached, :memcache, :mongo,
+                         :moped, :rack, :redis, :resque, :rest_client, :sequel,
+                         :typhoeus]
     ##
     # Return the raw nested hash.
     #
@@ -43,6 +44,7 @@ module Oboe
       Oboe::Config[:faraday][:collect_backtraces] = false
       Oboe::Config[:grape][:collect_backtraces] = true
       Oboe::Config[:em_http_request][:collect_backtraces] = false
+      Oboe::Config[:excon][:collect_backtraces] = true
       Oboe::Config[:memcache][:collect_backtraces] = false
       Oboe::Config[:memcached][:collect_backtraces] = false
       Oboe::Config[:mongo][:collect_backtraces] = true

--- a/lib/oboe/inst/excon.rb
+++ b/lib/oboe/inst/excon.rb
@@ -12,19 +12,19 @@ module Oboe
       def oboe_collect(params)
         kvs = {}
         kvs['IsService'] = 1
-        kvs['RemoteProtocol'] = @data[:scheme].upcase
+        kvs['RemoteProtocol'] = ::Oboe::Util.upcase(@data[:scheme])
         kvs['RemoteHost'] = @data[:host]
         kvs['ServiceArg'] = @data[:path]
 
         if params.is_a?(Array)
           methods = []
           params.each do |p|
-            methods << p[:method].to_s.upcase
+            methods << ::Oboe::Util.upcase(p[:method])
           end
           kvs['HTTPMethods'] = methods.join(', ')[0..1024]
           kvs['Pipeline'] = true
         else
-          kvs['HTTPMethod'] = params[:method].upcase
+          kvs['HTTPMethod'] = ::Oboe::Util.upcase(params[:method])
         end
         kvs['Backtrace'] = Oboe::API.backtrace if Oboe::Config[:excon][:collect_backtraces]
         kvs

--- a/lib/oboe/inst/excon.rb
+++ b/lib/oboe/inst/excon.rb
@@ -1,0 +1,81 @@
+# Copyright (c) 2015 AppNeta, Inc.
+# All rights reserved.
+
+module Oboe
+  module Inst
+    module ExconConnection
+      def self.included(klass)
+        ::Oboe::Util.method_alias(klass, :request, ::Excon::Connection)
+      end
+
+      def oboe_collect(params)
+          kvs = {}
+          kvs['IsService'] = 1
+          kvs['RemoteProtocol'] = @data[:scheme].upcase
+          kvs['RemoteHost'] = @data[:hostname]
+          kvs['ServiceArg'] = @data[:path]
+          kvs['HTTPMethod'] = params[:method].upcase
+          kvs['Pipelined'] = params[:pipeline]
+          kvs['Backtrace'] = Oboe::API.backtrace if Oboe::Config[:excon][:collect_backtraces]
+          kvs
+      rescue => e
+        Oboe.logger.debug "[oboe/debug] Error capturing excon KVs: #{e.message}"
+        Oboe.logger.debug e.backtrace.join('\n') if ::Oboe::Config[:verbose]
+      end
+
+      def request_with_oboe(params={}, &block)
+        # If we're not tracing, just do a fast return.
+        if !Oboe.tracing?
+          return request_without_oboe(params, &block)
+        end
+
+        begin
+          response_context = nil
+
+          # Avoid cross host tracing for blacklisted domains
+          blacklisted = Oboe::API.blacklisted?(@data[:hostname])
+
+          req_context = Oboe::Context.toString()
+          @data[:headers]['X-Trace'] = req_context unless blacklisted
+
+          kvs = oboe_collect(params)
+          kvs['Blacklisted'] = true if blacklisted
+
+          Oboe::API.log_entry('excon', kvs)
+          kvs.clear
+
+          # The core excon call
+          response = request_without_oboe(params, &block)
+
+          if response.is_a?(Hash)
+            response_context = response[:headers]["X-Trace"]
+          else
+            response_context = response.headers['X-Trace']
+            kvs['HTTPStatus'] = response.status
+
+            # If we get a redirect, report the location header
+            if ((300..308).to_a.include? response.status.to_i) && response.headers.key?("Location")
+              kvs["Location"] = response.headers["Location"]
+            end
+          end
+
+          if response_context && !blacklisted
+            Oboe::XTrace.continue_service_context(req_context, response_context)
+          end
+
+          response
+        rescue => e
+          Oboe::API.log_exception('excon', e)
+          raise e
+        ensure
+          Oboe::API.log_exit('excon', kvs)
+        end
+      end
+    end
+  end
+end
+
+if Oboe::Config[:excon][:enabled] && defined?(::Excon)
+  ::Oboe.logger.info '[oboe/loading] Instrumenting excon' if Oboe::Config[:verbose]
+  ::Oboe::Util.send_include(::Excon::Connection, ::Oboe::Inst::ExconConnection)
+end

--- a/lib/oboe/inst/excon.rb
+++ b/lib/oboe/inst/excon.rb
@@ -14,8 +14,15 @@ module Oboe
         kvs['IsService'] = 1
         kvs['RemoteProtocol'] = ::Oboe::Util.upcase(@data[:scheme])
         kvs['RemoteHost'] = @data[:host]
-        kvs['ServiceArg'] = @data[:path]
 
+        if @data[:query] && @data[:query].length
+          kvs['ServiceArg'] = @data[:path] + '?' + @data[:query]
+        else
+          kvs['ServiceArg'] = @data[:path]
+        end
+
+        # In the case of HTTP pipelining, params could be an array of
+        # request hashes.
         if params.is_a?(Array)
           methods = []
           params.each do |p|

--- a/lib/oboe/inst/faraday.rb
+++ b/lib/oboe/inst/faraday.rb
@@ -8,7 +8,8 @@ module Oboe
       def run_request_with_oboe(method, url, body, headers, &block)
         # Only send service KVs if we're not using the Net::HTTP adapter
         # Otherwise, the Net::HTTP instrumentation will send the service KVs
-        handle_service = !@builder.handlers.include?(Faraday::Adapter::NetHttp)
+        handle_service = !@builder.handlers.include?(Faraday::Adapter::NetHttp) &&
+                          !@builder.handlers.include?(Faraday::Adapter::Excon)
         Oboe::API.log_entry('faraday')
 
         result = run_request_without_oboe(method, url, body, headers, &block)

--- a/lib/oboe/inst/faraday.rb
+++ b/lib/oboe/inst/faraday.rb
@@ -15,7 +15,6 @@ module Oboe
         result = run_request_without_oboe(method, url, body, headers, &block)
 
         kvs = {}
-        kvs[:HTTPStatus] = result.status
         kvs['Middleware'] = @builder.handlers
         kvs['Backtrace'] = Oboe::API.backtrace if Oboe::Config[:faraday][:collect_backtraces]
 
@@ -34,6 +33,7 @@ module Oboe
           kvs['RemotePort'] = @url_prefix.port
           kvs['ServiceArg'] = url
           kvs['HTTPMethod'] = method
+          kvs[:HTTPStatus] = result.status
           kvs['Blacklisted'] = true if blacklisted
 
           # Re-attach net::http edge unless it's blacklisted or if we don't have a

--- a/lib/oboe/inst/http.rb
+++ b/lib/oboe/inst/http.rb
@@ -60,7 +60,7 @@ if Oboe::Config[:nethttp][:enabled]
           opts['HTTPStatus'] = resp.code
 
           # If we get a redirect, report the location header
-          if [300..308].include? resp.code.to_i && resp.header["Location"]
+          if ((300..308).to_a.include? resp.code.to_i) && resp.header["Location"]
             opts["Location"] = resp.header["Location"]
           end
 

--- a/lib/oboe/inst/rest-client.rb
+++ b/lib/oboe/inst/rest-client.rb
@@ -1,3 +1,6 @@
+# Copyright (c) 2015 AppNeta, Inc.
+# All rights reserved.
+
 module Oboe
   module Inst
     module RestClientRequest

--- a/lib/oboe/inst/sequel.rb
+++ b/lib/oboe/inst/sequel.rb
@@ -1,3 +1,6 @@
+# Copyright (c) 2015 AppNeta, Inc.
+# All rights reserved.
+
 module Oboe
   module Inst
     module Sequel

--- a/lib/oboe/inst/typhoeus.rb
+++ b/lib/oboe/inst/typhoeus.rb
@@ -33,11 +33,11 @@ module Oboe
 
         uri = URI(response.effective_url)
         kvs['IsService'] = 1
-        kvs['RemoteProtocol'] = uri.scheme
+        kvs['RemoteProtocol'] = ::Oboe::Util.upcase(uri.scheme)
         kvs['RemoteHost'] = uri.host
         kvs['RemotePort'] = uri.port ? uri.port : 80
         kvs['ServiceArg'] = uri.path
-        kvs['HTTPMethod'] = options[:method]
+        kvs['HTTPMethod'] = ::Oboe::Util.upcase(options[:method])
         kvs['Blacklisted'] = true if blacklisted
 
         # Re-attach net::http edge unless it's blacklisted or if we don't have a

--- a/lib/oboe/inst/typhoeus.rb
+++ b/lib/oboe/inst/typhoeus.rb
@@ -1,3 +1,6 @@
+# Copyright (c) 2015 AppNeta, Inc.
+# All rights reserved.
+
 module Oboe
   module Inst
     module TyphoeusRequestOps

--- a/lib/oboe/util.rb
+++ b/lib/oboe/util.rb
@@ -156,6 +156,7 @@ module Oboe
           # Report the instrumented libraries
           platform_info['Ruby.Cassandra.Version']  = "Cassandra-#{::Cassandra.VERSION}"    if defined?(::Cassandra)
           platform_info['Ruby.Dalli.Version']      = "Dalli-#{::Dalli::VERSION}"           if defined?(::Dalli)
+          platform_info['Ruby.Excon.Version']      = "Excon-#{::Excon::VERSION}"           if defined?(::Excon::VERSION)
           platform_info['Ruby.Faraday.Version']    = "Faraday-#{::Faraday::VERSION}"       if defined?(::Faraday)
           platform_info['Ruby.MemCache.Version']   = "MemCache-#{::MemCache::VERSION}"     if defined?(::MemCache)
           platform_info['Ruby.Moped.Version']      = "Moped-#{::Moped::VERSION}"           if defined?(::Moped)

--- a/lib/oboe/util.rb
+++ b/lib/oboe/util.rb
@@ -123,6 +123,22 @@ module Oboe
       end
 
       ##
+      # upcase
+      #
+      # Occasionally, we want to send some values in all caps.  This is true
+      # for things like HTTP scheme or method.  This takes anything and does
+      # it's best to safely convert it to a string (if needed) and convert it
+      # to all uppercase.
+      def upcase(o)
+        if o.is_a?(String) || o.respond_to?(:to_s)
+          o.to_s.upcase
+        else
+          Oboe.logger.debug "[oboe/debug] Oboe::Util.upcase: could not convert #{o.class}"
+          "UNKNOWN"
+        end
+      end
+
+      ##
       #  build_report
       #
       # Internal: Build a hash of KVs that reports on the status of the
@@ -191,7 +207,7 @@ module Oboe
             platform_info['Ruby.AppContainer.Version'] = "Mongrel2-#{::Mongrel2::VERSION}"
           elsif defined?(::Trinidad)
             platform_info['Ruby.AppContainer.Version'] = "Trinidad-#{::Trinidad::VERSION}"
-          elsif defined?(::WEBrick)
+          elsif defined?(::WEBrick::VERSION)
             platform_info['Ruby.AppContainer.Version'] = "WEBrick-#{::WEBrick::VERSION}"
           else
             platform_info['Ruby.AppContainer.Version'] = File.basename($PROGRAM_NAME)

--- a/test/instrumentation/excon_test.rb
+++ b/test/instrumentation/excon_test.rb
@@ -2,7 +2,7 @@ require 'minitest_helper'
 require 'oboe/inst/rack'
 require File.expand_path(File.dirname(__FILE__) + '../../frameworks/apps/sinatra_simple')
 
-class TestApp < Minitest::Test
+class ExconTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/instrumentation/excon_test.rb
+++ b/test/instrumentation/excon_test.rb
@@ -69,6 +69,9 @@ class ExconTest < Minitest::Test
   end
 
   def test_persistent_requests
+    # Persistence was adding in 0.31.0
+    skip if Excon::VERSION < '0.31.0'
+
     clear_all_traces
 
     Oboe::API.start_trace('excon_tests') do
@@ -108,6 +111,8 @@ class ExconTest < Minitest::Test
   end
 
   def test_pipelined_requests
+    skip if Excon::VERSION <= '0.17.0'
+
     clear_all_traces
 
     Oboe::API.start_trace('excon_tests') do

--- a/test/instrumentation/excon_test.rb
+++ b/test/instrumentation/excon_test.rb
@@ -27,22 +27,24 @@ class ExconTest < Minitest::Test
     clear_all_traces
 
     Oboe::API.start_trace('excon_tests') do
-      response = Excon.get('http://www.google.com/')
+      response = Excon.get('http://127.0.0.1:8101/')
     end
 
     traces = get_all_traces
-    assert_equal traces.count, 4
+    assert_equal traces.count, 7
     validate_outer_layers(traces, "excon_tests")
     valid_edges?(traces)
 
     assert_equal traces[1]['IsService'], 1
-    assert_equal traces[1]['RemoteHost'], 'www.google.com'
+    assert_equal traces[1]['RemoteHost'], '127.0.0.1'
     assert_equal traces[1]['RemoteProtocol'], 'HTTP'
     assert_equal traces[1]['ServiceArg'], '/'
     assert_equal traces[1]['HTTPMethod'], 'GET'
     assert traces[1].key?('Backtrace')
-    assert_equal traces[2]['HTTPStatus'], 302
-    assert traces[2].key?('Location')
+
+    assert_equal traces[5]['Layer'], 'excon'
+    assert_equal traces[5]['Label'], 'exit'
+    assert_equal traces[5]['HTTPStatus'], 200
   end
 
   def test_cross_app_tracing

--- a/test/instrumentation/excon_test.rb
+++ b/test/instrumentation/excon_test.rb
@@ -112,18 +112,20 @@ class TestApp < Minitest::Test
 
     Oboe::API.start_trace('excon_tests') do
       connection = Excon.new('http://www.gameface.in/')
-      connection.requests([{:method => :get}, {:method => :get}])
+      connection.requests([{:method => :get}, {:method => :put}])
     end
 
     traces = get_all_traces
-    assert_equal traces.count, 6
+    assert_equal traces.count, 4
     validate_outer_layers(traces, "excon_tests")
+    valid_edges?(traces)
 
     assert_equal traces[1]['IsService'], 1
     assert_equal traces[1]['RemoteHost'], 'www.gameface.in'
     assert_equal traces[1]['RemoteProtocol'], 'HTTP'
     assert_equal traces[1]['ServiceArg'], '/'
-    assert_equal traces[1]['HTTPMethod'], 'GET'
+    assert_equal traces[1]['Pipeline'], 'true'
+    assert_equal traces[1]['HTTPMethods'], 'GET, PUT'
     assert traces[1].key?('Backtrace')
   end
 

--- a/test/instrumentation/excon_test.rb
+++ b/test/instrumentation/excon_test.rb
@@ -1,0 +1,161 @@
+require 'minitest_helper'
+require 'oboe/inst/rack'
+require File.expand_path(File.dirname(__FILE__) + '../../frameworks/apps/sinatra_simple')
+
+class TestApp < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    SinatraSimple
+  end
+
+  def test_must_return_xtrace_header
+    clear_all_traces
+    get "/"
+    xtrace = last_response['X-Trace']
+    assert xtrace
+    assert Oboe::XTrace.valid?(xtrace)
+  end
+
+  def test_reports_version_init
+    init_kvs = ::Oboe::Util.build_init_report
+    assert init_kvs.key?('Ruby.Excon.Version')
+    assert_equal init_kvs['Ruby.Excon.Version'], "Excon-#{::Excon::VERSION}"
+  end
+
+  def test_class_get_request
+    clear_all_traces
+
+    Oboe::API.start_trace('excon_tests') do
+      response = Excon.get('http://www.google.com/')
+    end
+
+    traces = get_all_traces
+    assert_equal traces.count, 4
+    validate_outer_layers(traces, "excon_tests")
+    valid_edges?(traces)
+
+    assert_equal traces[1]['IsService'], 1
+    assert_equal traces[1]['RemoteHost'], 'www.google.com'
+    assert_equal traces[1]['RemoteProtocol'], 'HTTP'
+    assert_equal traces[1]['ServiceArg'], '/'
+    assert_equal traces[1]['HTTPMethod'], 'GET'
+    assert traces[1].key?('Backtrace')
+    assert_equal traces[2]['HTTPStatus'], 302
+    assert traces[2].key?('Location')
+  end
+
+  def test_cross_app_tracing
+    clear_all_traces
+
+    Oboe::API.start_trace('excon_tests') do
+      response = Excon.get('http://www.gameface.in/gamers')
+      xtrace = response.headers['X-Trace']
+      assert xtrace
+      assert Oboe::XTrace.valid?(xtrace)
+    end
+
+    traces = get_all_traces
+    assert_equal traces.count, 4
+    validate_outer_layers(traces, "excon_tests")
+
+    assert_equal traces[1]['IsService'], 1
+    assert_equal traces[1]['RemoteHost'], 'www.gameface.in'
+    assert_equal traces[1]['RemoteProtocol'], 'HTTP'
+    assert_equal traces[1]['ServiceArg'], '/gamers'
+    assert_equal traces[1]['HTTPMethod'], 'GET'
+    assert traces[1].key?('Backtrace')
+    assert_equal traces[2]['HTTPStatus'], 200
+  end
+
+  def test_persistent_requests
+    clear_all_traces
+
+    Oboe::API.start_trace('excon_tests') do
+      connection = Excon.new('http://www.gameface.in/') # non-persistent by default
+      connection.get # socket established, then closed
+      connection.get(:persistent => true) # socket established, left open
+      connection.get # socket reused, then closed
+    end
+
+    traces = get_all_traces
+    assert_equal traces.count, 8
+    validate_outer_layers(traces, "excon_tests")
+
+    assert_equal traces[1]['IsService'], 1
+    assert_equal traces[1]['RemoteHost'], 'www.gameface.in'
+    assert_equal traces[1]['RemoteProtocol'], 'HTTP'
+    assert_equal traces[1]['ServiceArg'], '/'
+    assert_equal traces[1]['HTTPMethod'], 'GET'
+    assert traces[1].key?('Backtrace')
+    assert_equal traces[2]['HTTPStatus'], 200
+
+    assert_equal traces[3]['IsService'], 1
+    assert_equal traces[3]['RemoteHost'], 'www.gameface.in'
+    assert_equal traces[3]['RemoteProtocol'], 'HTTP'
+    assert_equal traces[3]['ServiceArg'], '/'
+    assert_equal traces[3]['HTTPMethod'], 'GET'
+    assert traces[3].key?('Backtrace')
+    assert_equal traces[4]['HTTPStatus'], 200
+
+    assert_equal traces[5]['IsService'], 1
+    assert_equal traces[5]['RemoteHost'], 'www.gameface.in'
+    assert_equal traces[5]['RemoteProtocol'], 'HTTP'
+    assert_equal traces[5]['ServiceArg'], '/'
+    assert_equal traces[5]['HTTPMethod'], 'GET'
+    assert traces[5].key?('Backtrace')
+    assert_equal traces[6]['HTTPStatus'], 200
+  end
+
+  def test_pipelined_requests
+    clear_all_traces
+
+    Oboe::API.start_trace('excon_tests') do
+      connection = Excon.new('http://www.gameface.in/')
+      connection.requests([{:method => :get}, {:method => :get}])
+    end
+
+    traces = get_all_traces
+    assert_equal traces.count, 6
+    validate_outer_layers(traces, "excon_tests")
+
+    assert_equal traces[1]['IsService'], 1
+    assert_equal traces[1]['RemoteHost'], 'www.gameface.in'
+    assert_equal traces[1]['RemoteProtocol'], 'HTTP'
+    assert_equal traces[1]['ServiceArg'], '/'
+    assert_equal traces[1]['HTTPMethod'], 'GET'
+    assert traces[1].key?('Backtrace')
+  end
+
+  def test_requests_with_errors
+    clear_all_traces
+
+    begin
+      Oboe::API.start_trace('excon_tests') do
+        connection = Excon.get('http://asfjalkfjlajfljkaljf/')
+      end
+    rescue
+    end
+
+    traces = get_all_traces
+    assert_equal traces.count, 5
+    validate_outer_layers(traces, "excon_tests")
+
+    assert_equal traces[1]['IsService'], 1
+    assert_equal traces[1]['RemoteHost'], 'asfjalkfjlajfljkaljf'
+    assert_equal traces[1]['RemoteProtocol'], 'HTTP'
+    assert_equal traces[1]['ServiceArg'], '/'
+    assert_equal traces[1]['HTTPMethod'], 'GET'
+    assert traces[1].key?('Backtrace')
+
+    assert_equal traces[2]['Layer'], 'excon'
+    assert_equal traces[2]['Label'], 'error'
+    assert_equal traces[2]['ErrorClass'], "Excon::Errors::SocketError"
+    assert traces[2].key?('ErrorMsg')
+    assert traces[2].key?('Backtrace')
+
+    assert_equal traces[3]['Layer'], 'excon'
+    assert_equal traces[3]['Label'], 'exit'
+  end
+end
+

--- a/test/instrumentation/faraday_test.rb
+++ b/test/instrumentation/faraday_test.rb
@@ -150,7 +150,11 @@ describe Oboe::Inst::FaradayConnection do
 
     traces[4]['Layer'].must_equal 'faraday'
     traces[4]['Label'].must_equal 'info'
-    traces[4]['Middleware'].must_equal '[Faraday::Adapter::Excon]'
+    unless RUBY_VERSION < '1.9.3'
+      # FIXME: Ruby 1.8 is reporting an object instance instead of
+      # an array
+      traces[4]['Middleware'].must_equal '[Faraday::Adapter::Excon]'
+    end
 
     traces[5]['Layer'].must_equal 'faraday'
     traces[5]['Label'].must_equal 'exit'

--- a/test/instrumentation/faraday_test.rb
+++ b/test/instrumentation/faraday_test.rb
@@ -63,6 +63,7 @@ describe Oboe::Inst::FaradayConnection do
     traces = get_all_traces
     traces.count.must_equal 8
 
+    valid_edges?(traces)
     validate_outer_layers(traces, 'faraday_test')
 
     traces[1]['Layer'].must_equal 'faraday'
@@ -94,6 +95,7 @@ describe Oboe::Inst::FaradayConnection do
     traces = get_all_traces
     traces.count.must_equal 8
 
+    valid_edges?(traces)
     validate_outer_layers(traces, 'faraday_test')
 
     traces[1]['Layer'].must_equal 'faraday'
@@ -126,25 +128,32 @@ describe Oboe::Inst::FaradayConnection do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 5
+    traces.count.must_equal 7
 
+    valid_edges?(traces)
     validate_outer_layers(traces, 'faraday_test')
 
     traces[1]['Layer'].must_equal 'faraday'
     traces[1].key?('Backtrace').must_equal Oboe::Config[:faraday][:collect_backtraces]
 
+    traces[2]['Layer'].must_equal 'excon'
+    traces[2]['Label'].must_equal 'entry'
     traces[2]['IsService'].must_equal 1
     traces[2]['RemoteProtocol'].must_equal 'HTTP'
     traces[2]['RemoteHost'].must_equal 'www.curlmyip.de'
     traces[2]['ServiceArg'].must_equal '/?q=1'
-    traces[2]['HTTPMethod'].downcase.must_equal 'get'
+    traces[2]['HTTPMethod'].must_equal 'GET'
 
-    traces[2]['Layer'].must_equal 'faraday'
-    traces[2]['Label'].must_equal 'info'
-    traces[2]['HTTPStatus'].must_equal 200
-
-    traces[3]['Layer'].must_equal 'faraday'
+    traces[3]['Layer'].must_equal 'excon'
     traces[3]['Label'].must_equal 'exit'
+    traces[3]['HTTPStatus'].must_equal 200
+
+    traces[4]['Layer'].must_equal 'faraday'
+    traces[4]['Label'].must_equal 'info'
+    traces[4]['Middleware'].must_equal '[Faraday::Adapter::Excon]'
+
+    traces[5]['Layer'].must_equal 'faraday'
+    traces[5]['Label'].must_equal 'exit'
   end
 
   it 'should obey :collect_backtraces setting when true' do

--- a/test/instrumentation/typhoeus_test.rb
+++ b/test/instrumentation/typhoeus_test.rb
@@ -26,7 +26,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
   it 'should trace a typhoeus request' do
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.get("localhost:8101/")
+      Typhoeus.get("http://127.0.0.1:8101/")
     end
 
     traces = get_all_traces
@@ -42,7 +42,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
     traces[5]['Label'].must_equal 'info'
     traces[5]['IsService'].must_equal 1
     traces[5]['RemoteProtocol'].must_equal 'HTTP'
-    traces[5]['RemoteHost'].must_equal 'localhost'
+    traces[5]['RemoteHost'].must_equal '127.0.0.1'
     traces[5]['ServiceArg'].must_equal '/'
     traces[5]['HTTPMethod'].must_equal 'GET'
     traces[5]['HTTPStatus'].must_equal 200

--- a/test/instrumentation/typhoeus_test.rb
+++ b/test/instrumentation/typhoeus_test.rb
@@ -53,7 +53,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
   it 'should trace a typhoeus POST request' do
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.post("localhost:8101/",
+      Typhoeus.post("127.0.0.1:8101/",
                     :body => { :key => "oboe-ruby-fake", :content => "oboe-ruby repo test suite"})
     end
 
@@ -70,7 +70,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
     traces[5]['Label'].must_equal 'info'
     traces[5]['IsService'].must_equal 1
     traces[5]['RemoteProtocol'].must_equal 'HTTP'
-    traces[5]['RemoteHost'].must_equal 'localhost'
+    traces[5]['RemoteHost'].must_equal '127.0.0.1'
     traces[5]['RemotePort'].must_equal 8101
     traces[5]['ServiceArg'].must_equal '/'
     traces[5]['HTTPMethod'].must_equal 'POST'
@@ -82,7 +82,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
   it 'should trace a typhoeus PUT request' do
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.put("http://localhost:8101/",
+      Typhoeus.put("http://127.0.0.1:8101/",
                     :body => { :key => "oboe-ruby-fake", :content => "oboe-ruby repo test suite"})
     end
 
@@ -99,7 +99,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
     traces[5]['Label'].must_equal 'info'
     traces[5]['IsService'].must_equal 1
     traces[5]['RemoteProtocol'].must_equal 'HTTP'
-    traces[5]['RemoteHost'].must_equal 'localhost'
+    traces[5]['RemoteHost'].must_equal '127.0.0.1'
     traces[5]['RemotePort'].must_equal 8101
     traces[5]['ServiceArg'].must_equal '/'
     traces[5]['HTTPMethod'].must_equal 'PUT'
@@ -111,7 +111,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
   it 'should trace a typhoeus DELETE request' do
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.delete("http://localhost:8101/")
+      Typhoeus.delete("http://127.0.0.1:8101/")
     end
 
     traces = get_all_traces
@@ -127,7 +127,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
     traces[5]['Label'].must_equal 'info'
     traces[5]['IsService'].must_equal 1
     traces[5]['RemoteProtocol'].must_equal 'HTTP'
-    traces[5]['RemoteHost'].must_equal 'localhost'
+    traces[5]['RemoteHost'].must_equal '127.0.0.1'
     traces[5]['RemotePort'].must_equal 8101
     traces[5]['ServiceArg'].must_equal '/'
     traces[5]['HTTPMethod'].must_equal 'DELETE'
@@ -139,7 +139,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
   it 'should trace a typhoeus HEAD request' do
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.head("http://localhost:8101/")
+      Typhoeus.head("http://127.0.0.1:8101/")
     end
 
     traces = get_all_traces
@@ -155,7 +155,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
     traces[5]['Label'].must_equal 'info'
     traces[5]['IsService'].must_equal 1
     traces[5]['RemoteProtocol'].must_equal 'HTTP'
-    traces[5]['RemoteHost'].must_equal 'localhost'
+    traces[5]['RemoteHost'].must_equal '127.0.0.1'
     traces[5]['ServiceArg'].must_equal '/'
     traces[5]['HTTPMethod'].must_equal 'HEAD'
     traces[5]['HTTPStatus'].must_equal 200
@@ -166,7 +166,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
   it 'should trace a typhoeus GET request to an instr\'d app' do
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.get("localhost:8101")
+      Typhoeus.get("127.0.0.1:8101")
     end
 
     traces = get_all_traces
@@ -182,7 +182,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
     traces[5]['Label'].must_equal 'info'
     traces[5]['IsService'].must_equal 1
     traces[5]['RemoteProtocol'].must_equal 'HTTP'
-    traces[5]['RemoteHost'].must_equal 'localhost'
+    traces[5]['RemoteHost'].must_equal '127.0.0.1'
     traces[5]['ServiceArg'].must_equal '/'
     traces[5]['HTTPMethod'].must_equal 'GET'
     traces[5]['HTTPStatus'].must_equal 200
@@ -228,9 +228,9 @@ describe Oboe::Inst::TyphoeusRequestOps do
     Oboe::API.start_trace('typhoeus_test') do
       hydra = Typhoeus::Hydra.hydra
 
-      first_request  = Typhoeus::Request.new("localhost:8101/products/traceview/")
-      second_request = Typhoeus::Request.new("localhost:8101/products/")
-      third_request  = Typhoeus::Request.new("localhost:8101/")
+      first_request  = Typhoeus::Request.new("127.0.0.1:8101/products/traceview/")
+      second_request = Typhoeus::Request.new("127.0.0.1:8101/products/")
+      third_request  = Typhoeus::Request.new("127.0.0.1:8101/")
 
       hydra.queue first_request
       hydra.queue second_request
@@ -258,7 +258,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
     Oboe::Config[:typhoeus][:collect_backtraces] = true
 
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.get("localhost:8101/")
+      Typhoeus.get("127.0.0.1:8101/")
     end
 
     traces = get_all_traces
@@ -269,7 +269,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
     Oboe::Config[:typhoeus][:collect_backtraces] = false
 
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.get("localhost:8101/")
+      Typhoeus.get("127.0.0.1:8101/")
     end
 
     traces = get_all_traces

--- a/test/instrumentation/typhoeus_test.rb
+++ b/test/instrumentation/typhoeus_test.rb
@@ -69,7 +69,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
     traces[2]['RemotePort'].must_equal 443
     traces[2]['ServiceArg'].must_equal '/api-v2/log_message'
     traces[2]['HTTPMethod'].must_equal 'post'
-    traces[2]['HTTPStatus'].must_equal 302
+    traces[2]['HTTPStatus'].must_equal 502
 
     traces[3]['Layer'].must_equal 'typhoeus'
     traces[3]['Label'].must_equal 'exit'
@@ -77,7 +77,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
   it 'should trace a typhoeus PUT request' do
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.put("https://internal.tv.appneta.com/api-v2/log_message",
+      Typhoeus.put("https://api.tv.appneta.com/api-v2/log_message",
                     :body => { :key => "oboe-ruby-fake", :content => "oboe-ruby repo test suite"})
     end
 
@@ -93,11 +93,11 @@ describe Oboe::Inst::TyphoeusRequestOps do
     traces[2]['Label'].must_equal 'info'
     traces[2]['IsService'].must_equal 1
     traces[2]['RemoteProtocol'].downcase.must_equal 'https'
-    traces[2]['RemoteHost'].must_equal 'internal.tv.appneta.com'
+    traces[2]['RemoteHost'].must_equal 'api.tv.appneta.com'
     traces[2]['RemotePort'].must_equal 443
     traces[2]['ServiceArg'].must_equal '/api-v2/log_message'
     traces[2]['HTTPMethod'].must_equal 'put'
-    traces[2]['HTTPStatus'].must_equal 405
+    traces[2]['HTTPStatus'].must_equal 502
 
     traces[3]['Layer'].must_equal 'typhoeus'
     traces[3]['Label'].must_equal 'exit'
@@ -105,7 +105,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
   it 'should trace a typhoeus DELETE request' do
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.delete("https://internal.tv.appneta.com/api-v2/log_message")
+      Typhoeus.delete("https://api.tv.appneta.com/api-v2/log_message")
     end
 
     traces = get_all_traces
@@ -120,11 +120,11 @@ describe Oboe::Inst::TyphoeusRequestOps do
     traces[2]['Label'].must_equal 'info'
     traces[2]['IsService'].must_equal 1
     traces[2]['RemoteProtocol'].downcase.must_equal 'https'
-    traces[2]['RemoteHost'].must_equal 'internal.tv.appneta.com'
+    traces[2]['RemoteHost'].must_equal 'api.tv.appneta.com'
     traces[2]['RemotePort'].must_equal 443
     traces[2]['ServiceArg'].must_equal '/api-v2/log_message'
     traces[2]['HTTPMethod'].must_equal 'delete'
-    traces[2]['HTTPStatus'].must_equal 405
+    traces[2]['HTTPStatus'].must_equal 502
 
     traces[3]['Layer'].must_equal 'typhoeus'
     traces[3]['Label'].must_equal 'exit'

--- a/test/instrumentation/typhoeus_test.rb
+++ b/test/instrumentation/typhoeus_test.rb
@@ -166,7 +166,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
   it 'should trace a typhoeus GET request to an instr\'d app' do
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.get("127.0.0.1:8101")
+      Typhoeus.get("127.0.0.1:8101/")
     end
 
     traces = get_all_traces

--- a/test/instrumentation/typhoeus_test.rb
+++ b/test/instrumentation/typhoeus_test.rb
@@ -1,3 +1,6 @@
+# Copyright (c) 2015 AppNeta, Inc.
+# All rights reserved.
+
 require 'minitest_helper'
 require 'rack'
 
@@ -23,211 +26,165 @@ describe Oboe::Inst::TyphoeusRequestOps do
 
   it 'should trace a typhoeus request' do
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.get("www.appneta.com/products/traceview/")
-    end
-
-    traces = get_all_traces
-    traces.count.must_equal 5
-
-    validate_outer_layers(traces, 'typhoeus_test')
-
-    traces[1]['Layer'].must_equal 'typhoeus'
-    traces[1].key?('Backtrace').must_equal Oboe::Config[:typhoeus][:collect_backtraces]
-
-    traces[2]['Layer'].must_equal 'typhoeus'
-    traces[2]['Label'].must_equal 'info'
-    traces[2]['IsService'].must_equal 1
-    traces[2]['RemoteProtocol'].downcase.must_equal 'http'
-    traces[2]['RemoteHost'].must_equal 'www.appneta.com'
-    traces[2]['ServiceArg'].must_equal '/products/traceview/'
-    traces[2]['HTTPMethod'].must_equal 'get'
-    traces[2]['HTTPStatus'].must_equal 200
-
-    traces[3]['Layer'].must_equal 'typhoeus'
-    traces[3]['Label'].must_equal 'exit'
-  end
-
-  it 'should trace a typhoeus POST request' do
-    Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.post("https://internal.tv.appneta.com/api-v2/log_message",
-                    :body => { :key => "oboe-ruby-fake", :content => "oboe-ruby repo test suite"})
-    end
-
-    traces = get_all_traces
-    traces.count.must_equal 5
-
-    validate_outer_layers(traces, 'typhoeus_test')
-
-    traces[1]['Layer'].must_equal 'typhoeus'
-    traces[1].key?('Backtrace').must_equal Oboe::Config[:typhoeus][:collect_backtraces]
-
-    traces[2]['Layer'].must_equal 'typhoeus'
-    traces[2]['Label'].must_equal 'info'
-    traces[2]['IsService'].must_equal 1
-    traces[2]['RemoteProtocol'].downcase.must_equal 'https'
-    traces[2]['RemoteHost'].must_equal 'internal.tv.appneta.com'
-    traces[2]['RemotePort'].must_equal 443
-    traces[2]['ServiceArg'].must_equal '/api-v2/log_message'
-    traces[2]['HTTPMethod'].must_equal 'post'
-    traces[2]['HTTPStatus'].must_equal 502
-
-    traces[3]['Layer'].must_equal 'typhoeus'
-    traces[3]['Label'].must_equal 'exit'
-  end
-
-  it 'should trace a typhoeus PUT request' do
-    Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.put("https://api.tv.appneta.com/api-v2/log_message",
-                    :body => { :key => "oboe-ruby-fake", :content => "oboe-ruby repo test suite"})
-    end
-
-    traces = get_all_traces
-    traces.count.must_equal 5
-
-    validate_outer_layers(traces, 'typhoeus_test')
-
-    traces[1]['Layer'].must_equal 'typhoeus'
-    traces[1].key?('Backtrace').must_equal Oboe::Config[:typhoeus][:collect_backtraces]
-
-    traces[2]['Layer'].must_equal 'typhoeus'
-    traces[2]['Label'].must_equal 'info'
-    traces[2]['IsService'].must_equal 1
-    traces[2]['RemoteProtocol'].downcase.must_equal 'https'
-    traces[2]['RemoteHost'].must_equal 'api.tv.appneta.com'
-    traces[2]['RemotePort'].must_equal 443
-    traces[2]['ServiceArg'].must_equal '/api-v2/log_message'
-    traces[2]['HTTPMethod'].must_equal 'put'
-    traces[2]['HTTPStatus'].must_equal 502
-
-    traces[3]['Layer'].must_equal 'typhoeus'
-    traces[3]['Label'].must_equal 'exit'
-  end
-
-  it 'should trace a typhoeus DELETE request' do
-    Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.delete("https://api.tv.appneta.com/api-v2/log_message")
-    end
-
-    traces = get_all_traces
-    traces.count.must_equal 5
-
-    validate_outer_layers(traces, 'typhoeus_test')
-
-    traces[1]['Layer'].must_equal 'typhoeus'
-    traces[1].key?('Backtrace').must_equal Oboe::Config[:typhoeus][:collect_backtraces]
-
-    traces[2]['Layer'].must_equal 'typhoeus'
-    traces[2]['Label'].must_equal 'info'
-    traces[2]['IsService'].must_equal 1
-    traces[2]['RemoteProtocol'].downcase.must_equal 'https'
-    traces[2]['RemoteHost'].must_equal 'api.tv.appneta.com'
-    traces[2]['RemotePort'].must_equal 443
-    traces[2]['ServiceArg'].must_equal '/api-v2/log_message'
-    traces[2]['HTTPMethod'].must_equal 'delete'
-    traces[2]['HTTPStatus'].must_equal 502
-
-    traces[3]['Layer'].must_equal 'typhoeus'
-    traces[3]['Label'].must_equal 'exit'
-  end
-
-  it 'should trace a typhoeus HEAD request' do
-    Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.head("http://www.appneta.com/")
-    end
-
-    traces = get_all_traces
-    traces.count.must_equal 5
-
-    validate_outer_layers(traces, 'typhoeus_test')
-
-    traces[1]['Layer'].must_equal 'typhoeus'
-    traces[1].key?('Backtrace').must_equal Oboe::Config[:typhoeus][:collect_backtraces]
-
-    traces[2]['Layer'].must_equal 'typhoeus'
-    traces[2]['Label'].must_equal 'info'
-    traces[2]['IsService'].must_equal 1
-    traces[2]['RemoteProtocol'].downcase.must_equal 'http'
-    traces[2]['RemoteHost'].must_equal 'www.appneta.com'
-    traces[2]['ServiceArg'].must_equal '/'
-    traces[2]['HTTPMethod'].must_equal 'head'
-    traces[2]['HTTPStatus'].must_equal 200
-
-    traces[3]['Layer'].must_equal 'typhoeus'
-    traces[3]['Label'].must_equal 'exit'
-  end
-
-  it 'should trace a typhoeus GET request to an instr\'d app' do
-    Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.get("www.gameface.in/gamers")
-    end
-
-    traces = get_all_traces
-    traces.count.must_equal 5
-
-    validate_outer_layers(traces, 'typhoeus_test')
-
-    traces[1]['Layer'].must_equal 'typhoeus'
-    traces[1].key?('Backtrace').must_equal Oboe::Config[:typhoeus][:collect_backtraces]
-
-    traces[2]['Layer'].must_equal 'typhoeus'
-    traces[2]['Label'].must_equal 'info'
-    traces[2]['IsService'].must_equal 1
-    traces[2]['RemoteProtocol'].downcase.must_equal 'http'
-    traces[2]['RemoteHost'].must_equal 'www.gameface.in'
-    traces[2]['ServiceArg'].must_equal '/gamers'
-    traces[2]['HTTPMethod'].must_equal 'get'
-    traces[2]['HTTPStatus'].must_equal 200
-
-    traces[3]['Layer'].must_equal 'typhoeus'
-    traces[3]['Label'].must_equal 'exit'
-  end
-
-  it 'should trace a typhoeus GET request to an internal app' do
-    # TODO: JRuby doesn't trace the inner rack app for some reason...
-    skip if defined?(JRUBY_VERSION)
-
-    Thread.new do
-      app = Rack::Builder.new {
-        use Oboe::Rack
-        run Proc.new { |env|
-          [200, {"Content-Type" => "text/html"}, ['Hello, world!']]
-        }
-      }
-
-      Rack::Handler::WEBrick.run(app, :Port => 8000)
-    end
-
-    sleep(1)
-
-    Oboe::API.start_trace('outer') do
-      res = Typhoeus.get("127.0.0.1:8000/")
+      Typhoeus.get("localhost:8101/")
     end
 
     traces = get_all_traces
     traces.count.must_equal 8
 
-    validate_outer_layers(traces, 'outer')
+    valid_edges?(traces).must_equal true
+    validate_outer_layers(traces, 'typhoeus_test')
 
-    traces[2]['Layer'].must_equal 'rack'
-    traces[2]['Label'].must_equal 'entry'
-    traces[4]['Layer'].must_equal 'rack'
-    traces[4]['Label'].must_equal 'exit'
-
-    # Verify typhoeus info edges to inner exit
-    traces[6]['Edge'].must_equal traces[5]['X-Trace'][42...58]
-
-    # Verify typhoeus events
     traces[1]['Layer'].must_equal 'typhoeus'
     traces[1].key?('Backtrace').must_equal Oboe::Config[:typhoeus][:collect_backtraces]
 
     traces[5]['Layer'].must_equal 'typhoeus'
     traces[5]['Label'].must_equal 'info'
     traces[5]['IsService'].must_equal 1
-    traces[5]['RemoteProtocol'].downcase.must_equal 'http'
-    traces[5]['RemoteHost'].must_equal '127.0.0.1'
-    traces[5]['RemotePort'].must_equal 8000
+    traces[5]['RemoteProtocol'].must_equal 'HTTP'
+    traces[5]['RemoteHost'].must_equal 'localhost'
     traces[5]['ServiceArg'].must_equal '/'
-    traces[5]['HTTPMethod'].must_equal 'get'
+    traces[5]['HTTPMethod'].must_equal 'GET'
+    traces[5]['HTTPStatus'].must_equal 200
+
+    traces[6]['Layer'].must_equal 'typhoeus'
+    traces[6]['Label'].must_equal 'exit'
+  end
+
+  it 'should trace a typhoeus POST request' do
+    Oboe::API.start_trace('typhoeus_test') do
+      Typhoeus.post("localhost:8101/",
+                    :body => { :key => "oboe-ruby-fake", :content => "oboe-ruby repo test suite"})
+    end
+
+    traces = get_all_traces
+    traces.count.must_equal 8
+
+    valid_edges?(traces).must_equal true
+    validate_outer_layers(traces, 'typhoeus_test')
+
+    traces[1]['Layer'].must_equal 'typhoeus'
+    traces[1].key?('Backtrace').must_equal Oboe::Config[:typhoeus][:collect_backtraces]
+
+    traces[5]['Layer'].must_equal 'typhoeus'
+    traces[5]['Label'].must_equal 'info'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteProtocol'].must_equal 'HTTP'
+    traces[5]['RemoteHost'].must_equal 'localhost'
+    traces[5]['RemotePort'].must_equal 8101
+    traces[5]['ServiceArg'].must_equal '/'
+    traces[5]['HTTPMethod'].must_equal 'POST'
+    traces[5]['HTTPStatus'].must_equal 200
+
+    traces[6]['Layer'].must_equal 'typhoeus'
+    traces[6]['Label'].must_equal 'exit'
+  end
+
+  it 'should trace a typhoeus PUT request' do
+    Oboe::API.start_trace('typhoeus_test') do
+      Typhoeus.put("http://localhost:8101/",
+                    :body => { :key => "oboe-ruby-fake", :content => "oboe-ruby repo test suite"})
+    end
+
+    traces = get_all_traces
+    traces.count.must_equal 8
+
+    valid_edges?(traces).must_equal true
+    validate_outer_layers(traces, 'typhoeus_test')
+
+    traces[1]['Layer'].must_equal 'typhoeus'
+    traces[1].key?('Backtrace').must_equal Oboe::Config[:typhoeus][:collect_backtraces]
+
+    traces[5]['Layer'].must_equal 'typhoeus'
+    traces[5]['Label'].must_equal 'info'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteProtocol'].must_equal 'HTTP'
+    traces[5]['RemoteHost'].must_equal 'localhost'
+    traces[5]['RemotePort'].must_equal 8101
+    traces[5]['ServiceArg'].must_equal '/'
+    traces[5]['HTTPMethod'].must_equal 'PUT'
+    traces[5]['HTTPStatus'].must_equal 200
+
+    traces[6]['Layer'].must_equal 'typhoeus'
+    traces[6]['Label'].must_equal 'exit'
+  end
+
+  it 'should trace a typhoeus DELETE request' do
+    Oboe::API.start_trace('typhoeus_test') do
+      Typhoeus.delete("http://localhost:8101/")
+    end
+
+    traces = get_all_traces
+    traces.count.must_equal 8
+
+    valid_edges?(traces).must_equal true
+    validate_outer_layers(traces, 'typhoeus_test')
+
+    traces[1]['Layer'].must_equal 'typhoeus'
+    traces[1].key?('Backtrace').must_equal Oboe::Config[:typhoeus][:collect_backtraces]
+
+    traces[5]['Layer'].must_equal 'typhoeus'
+    traces[5]['Label'].must_equal 'info'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteProtocol'].must_equal 'HTTP'
+    traces[5]['RemoteHost'].must_equal 'localhost'
+    traces[5]['RemotePort'].must_equal 8101
+    traces[5]['ServiceArg'].must_equal '/'
+    traces[5]['HTTPMethod'].must_equal 'DELETE'
+    traces[5]['HTTPStatus'].must_equal 200
+
+    traces[6]['Layer'].must_equal 'typhoeus'
+    traces[6]['Label'].must_equal 'exit'
+  end
+
+  it 'should trace a typhoeus HEAD request' do
+    Oboe::API.start_trace('typhoeus_test') do
+      Typhoeus.head("http://localhost:8101/")
+    end
+
+    traces = get_all_traces
+    traces.count.must_equal 8
+
+    valid_edges?(traces).must_equal true
+    validate_outer_layers(traces, 'typhoeus_test')
+
+    traces[1]['Layer'].must_equal 'typhoeus'
+    traces[1].key?('Backtrace').must_equal Oboe::Config[:typhoeus][:collect_backtraces]
+
+    traces[5]['Layer'].must_equal 'typhoeus'
+    traces[5]['Label'].must_equal 'info'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteProtocol'].must_equal 'HTTP'
+    traces[5]['RemoteHost'].must_equal 'localhost'
+    traces[5]['ServiceArg'].must_equal '/'
+    traces[5]['HTTPMethod'].must_equal 'HEAD'
+    traces[5]['HTTPStatus'].must_equal 200
+
+    traces[6]['Layer'].must_equal 'typhoeus'
+    traces[6]['Label'].must_equal 'exit'
+  end
+
+  it 'should trace a typhoeus GET request to an instr\'d app' do
+    Oboe::API.start_trace('typhoeus_test') do
+      Typhoeus.get("localhost:8101")
+    end
+
+    traces = get_all_traces
+    traces.count.must_equal 8
+
+    valid_edges?(traces).must_equal true
+    validate_outer_layers(traces, 'typhoeus_test')
+
+    traces[1]['Layer'].must_equal 'typhoeus'
+    traces[1].key?('Backtrace').must_equal Oboe::Config[:typhoeus][:collect_backtraces]
+
+    traces[5]['Layer'].must_equal 'typhoeus'
+    traces[5]['Label'].must_equal 'info'
+    traces[5]['IsService'].must_equal 1
+    traces[5]['RemoteProtocol'].must_equal 'HTTP'
+    traces[5]['RemoteHost'].must_equal 'localhost'
+    traces[5]['ServiceArg'].must_equal '/'
+    traces[5]['HTTPMethod'].must_equal 'GET'
     traces[5]['HTTPStatus'].must_equal 200
 
     traces[6]['Layer'].must_equal 'typhoeus'
@@ -242,6 +199,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
     traces = get_all_traces
     traces.count.must_equal 6
 
+    valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
 
     traces[1]['Layer'].must_equal 'typhoeus'
@@ -253,10 +211,10 @@ describe Oboe::Inst::TyphoeusRequestOps do
     traces[3]['Layer'].must_equal 'typhoeus'
     traces[3]['Label'].must_equal 'info'
     traces[3]['IsService'].must_equal 1
-    traces[3]['RemoteProtocol'].downcase.must_equal 'http'
+    traces[3]['RemoteProtocol'].must_equal 'HTTP'
     traces[3]['RemoteHost'].must_equal 'thisdomaindoesntexisthopefully.asdf'
     traces[3]['ServiceArg'].must_equal '/products/traceview/'
-    traces[3]['HTTPMethod'].must_equal 'get'
+    traces[3]['HTTPMethod'].must_equal 'GET'
     traces[3]['HTTPStatus'].must_equal 0
 
     traces[3]['Layer'].must_equal 'typhoeus'
@@ -270,9 +228,9 @@ describe Oboe::Inst::TyphoeusRequestOps do
     Oboe::API.start_trace('typhoeus_test') do
       hydra = Typhoeus::Hydra.hydra
 
-      first_request  = Typhoeus::Request.new("www.appneta.com/products/traceview/")
-      second_request = Typhoeus::Request.new("www.appneta.com/products/")
-      third_request  = Typhoeus::Request.new("www.curlmyip.de")
+      first_request  = Typhoeus::Request.new("localhost:8101/products/traceview/")
+      second_request = Typhoeus::Request.new("localhost:8101/products/")
+      third_request  = Typhoeus::Request.new("localhost:8101/")
 
       hydra.queue first_request
       hydra.queue second_request
@@ -282,22 +240,25 @@ describe Oboe::Inst::TyphoeusRequestOps do
     end
 
     traces = get_all_traces
-    traces.count.must_equal 4
+    traces.count.must_equal 13
 
+    # FIXME: Until we support async tracing for Typhoeus, this won't
+    # work.
+    # valid_edges?(traces).must_equal true
     validate_outer_layers(traces, 'typhoeus_test')
 
     traces[1]['Layer'].must_equal 'typhoeus_hydra'
     traces[1]['Label'].must_equal 'entry'
 
-    traces[2]['Layer'].must_equal 'typhoeus_hydra'
-    traces[2]['Label'].must_equal 'exit'
+    traces[11]['Layer'].must_equal 'typhoeus_hydra'
+    traces[11]['Label'].must_equal 'exit'
   end
 
   it 'should obey :collect_backtraces setting when true' do
     Oboe::Config[:typhoeus][:collect_backtraces] = true
 
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.get("www.appneta.com/products/traceview/")
+      Typhoeus.get("localhost:8101/")
     end
 
     traces = get_all_traces
@@ -308,7 +269,7 @@ describe Oboe::Inst::TyphoeusRequestOps do
     Oboe::Config[:typhoeus][:collect_backtraces] = false
 
     Oboe::API.start_trace('typhoeus_test') do
-      Typhoeus.get("www.appneta.com/products/traceview/")
+      Typhoeus.get("localhost:8101/")
     end
 
     traces = get_all_traces

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -27,9 +27,6 @@ require 'memcache'
 
 Bundler.require(:default, :test)
 
-# Our background Rack-app for http client testing
-require "./test/servers/rackapp_8101"
-
 @trace_dir = "/tmp/"
 $trace_file = @trace_dir + "trace_output.bson"
 
@@ -38,6 +35,9 @@ Oboe::Config[:verbose] = true
 Oboe::Config[:tracing_mode] = "always"
 Oboe::Config[:sample_rate] = 1000000
 Oboe.logger.level = Logger::DEBUG
+
+# Our background Rack-app for http client testing
+require "./test/servers/rackapp_8101"
 
 ##
 # clear_all_traces

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -27,6 +27,9 @@ require 'memcache'
 
 Bundler.require(:default, :test)
 
+# Our background Rack-app for http client testing
+require "./test/servers/rackapp_8101"
+
 @trace_dir = "/tmp/"
 $trace_file = @trace_dir + "trace_output.bson"
 

--- a/test/servers/rackapp_8101.rb
+++ b/test/servers/rackapp_8101.rb
@@ -1,17 +1,20 @@
 # Copyright (c) 2015 AppNeta, Inc.
 # All rights reserved.
 
+require 'rack/handler/puma'
+require 'oboe/inst/rack'
+
 Oboe.logger.info "[oboe/info] Starting background utility rack app on localhost:8101."
 
 Thread.new do
   app = Rack::Builder.new {
     use Oboe::Rack
     run Proc.new { |env|
-      [200, {"Content-Type" => "text/html"}, ['Hello, world!']]
+      [200, {"Content-Type" => "text/html"}, ['Hello TraceView!']]
     }
   }
 
-  Rack::Handler::Thin.run(app, :Port => 8101)
+  Rack::Handler::Puma.run(app, {:Host => '127.0.0.1', :Port => 8101})
 end
 
 # Allow Thin to boot.

--- a/test/servers/rackapp_8101.rb
+++ b/test/servers/rackapp_8101.rb
@@ -1,0 +1,19 @@
+# Copyright (c) 2015 AppNeta, Inc.
+# All rights reserved.
+
+Oboe.logger.info "[oboe/info] Starting background utility rack app on localhost:8101."
+
+Thread.new do
+  app = Rack::Builder.new {
+    use Oboe::Rack
+    run Proc.new { |env|
+      [200, {"Content-Type" => "text/html"}, ['Hello, world!']]
+    }
+  }
+
+  Rack::Handler::Thin.run(app, :Port => 8101)
+end
+
+# Allow Thin to boot.
+sleep(2)
+

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -23,7 +23,7 @@ describe Oboe::Config do
     instrumentation = Oboe::Config.instrumentation_list
 
     # Verify the number of individual instrumentations
-    instrumentation.count.must_equal 19
+    instrumentation.count.must_equal 20
 
     Oboe::Config[:action_controller][:enabled].must_equal true
     Oboe::Config[:action_view][:enabled].must_equal true


### PR DESCRIPTION
Let's instrument this Usable, fast, simple HTTP 1.1 for Ruby

https://github.com/excon/excon

- [x] Add to `Oboe::Config` and update support tests
- [x] Core instrumentation
- [x] Test coverage
- [x] Add request exceptions tests
- [x] Fix broken traces with pipelined requests
- [x] Backtest to validate supported versions
- [x] Benchmark instrumentation against vanilla

Post-release:
- [ ] Add to support matrix