### PR TITLE
Add missing backcompat support bits

### DIFF
--- a/lib/oboe/backward_compatibility.rb
+++ b/lib/oboe/backward_compatibility.rb
@@ -17,7 +17,7 @@ module Oboe
       unless @deprecated_notified
         TraceView.logger.warn "[traceview/warn] Note that Oboe::API has been renamed to TraceView::API. (#{sym}:#{args})"
         TraceView.logger.warn "[traceview/warn] Oboe::API will be deprecated in a future version."
-        TraceView.logger.warn "[traceview/warn] File:Line: #{Kernel.caller[0]}"
+        TraceView.logger.warn "[traceview/warn] Caller: #{Kernel.caller[0]}"
         @deprecated_notified = true
       end
       TraceView::API.send(sym, *args, &blk)
@@ -37,7 +37,7 @@ module Oboe
       unless @deprecated_notified
         TraceView.logger.warn "[traceview/warn] Note that Oboe::Config has been renamed to TraceView::Config. (#{sym}:#{args})"
         TraceView.logger.warn "[traceview/warn] Oboe::Config will be deprecated in a future version."
-        TraceView.logger.warn "[traceview/warn] File:Line: #{Kernel.caller[0]}"
+        TraceView.logger.warn "[traceview/warn] Caller: #{Kernel.caller[0]}"
         @deprecated_notified = true
       end
       TraceView::Config.send(sym, *args)
@@ -56,7 +56,7 @@ module Oboe
       unless @deprecated_notified
         TraceView.logger.warn "[traceview/warn] Note that Oboe::Ruby has been renamed to TraceView::Ruby. (#{sym}:#{args})"
         TraceView.logger.warn "[traceview/warn] Oboe::Ruby will be deprecated in a future version."
-        TraceView.logger.warn "[traceview/warn] File:Line: #{Kernel.caller[0]}"
+        TraceView.logger.warn "[traceview/warn] Caller: #{Kernel.caller[0]}"
         @deprecated_notified = true
       end
       TraceView::Ruby.send(sym, *args)

--- a/lib/oboe/backward_compatibility.rb
+++ b/lib/oboe/backward_compatibility.rb
@@ -17,6 +17,7 @@ module Oboe
       unless @deprecated_notified
         TraceView.logger.warn "[traceview/warn] Note that Oboe::API has been renamed to TraceView::API. (#{sym}:#{args})"
         TraceView.logger.warn "[traceview/warn] Oboe::API will be deprecated in a future version."
+        TraceView.logger.warn "[traceview/warn] File:Line: #{Kernel.caller[0]}"
         @deprecated_notified = true
       end
       TraceView::API.send(sym, *args, &blk)
@@ -36,9 +37,29 @@ module Oboe
       unless @deprecated_notified
         TraceView.logger.warn "[traceview/warn] Note that Oboe::Config has been renamed to TraceView::Config. (#{sym}:#{args})"
         TraceView.logger.warn "[traceview/warn] Oboe::Config will be deprecated in a future version."
+        TraceView.logger.warn "[traceview/warn] File:Line: #{Kernel.caller[0]}"
         @deprecated_notified = true
       end
       TraceView::Config.send(sym, *args)
+    end
+  end
+
+  #
+  # Support for legacy Oboe::Ruby.load calls
+  #
+  module Ruby
+    extend ::TraceView::ThreadLocal
+    thread_local :deprecation_notified
+
+    def self.method_missing(sym, *args)
+      # Notify of deprecation only once
+      unless @deprecated_notified
+        TraceView.logger.warn "[traceview/warn] Note that Oboe::Ruby has been renamed to TraceView::Ruby. (#{sym}:#{args})"
+        TraceView.logger.warn "[traceview/warn] Oboe::Ruby will be deprecated in a future version."
+        TraceView.logger.warn "[traceview/warn] File:Line: #{Kernel.caller[0]}"
+        @deprecated_notified = true
+      end
+      TraceView::Ruby.send(sym, *args)
     end
   end
 end

--- a/lib/rails/generators/traceview/install_generator.rb
+++ b/lib/rails/generators/traceview/install_generator.rb
@@ -1,15 +1,14 @@
 # Copyright (c) 2013 AppNeta, Inc.
 # All rights reserved.
 
-module Oboe
+module TraceView
   class InstallGenerator < ::Rails::Generators::Base
     source_root File.join(File.dirname(__FILE__), 'templates')
-    desc "Copies an oboe initializer files to your application."
+    desc "Copies a TraceView gem initializer file to your application."
 
     def copy_initializer
       # Set defaults
       @tracing_mode = 'through'
-      @sample_rate = '300000'
       @verbose = 'false'
 
       print_header
@@ -32,7 +31,7 @@ module Oboe
 
       print_footer
 
-      template "oboe_initializer.rb", "config/initializers/traceview.rb"
+      template "traceview_initializer.rb", "config/initializers/traceview.rb"
     end
 
     private
@@ -46,11 +45,11 @@ module Oboe
         say shell.set_color "Documentation Links", :magenta
         say "-------------------"
         say ""
-        say "Details on configuring your sample rate:"
-        say "https://support.appneta.com/cloud/configuring-sampling"
+        say "TraceView Installation Overview:"
+        say "https://docs.appneta.com/installation-overview"
         say ""
         say "More information on instrumenting Ruby applications can be found here:"
-        say "https://support.appneta.com/cloud/installing-ruby-instrumentation"
+        say "https://docs.appneta.com/installing-ruby-instrumentation"
       end
 
       def print_body

--- a/lib/rails/generators/traceview/templates/traceview_initializer.rb
+++ b/lib/rails/generators/traceview/templates/traceview_initializer.rb
@@ -1,4 +1,4 @@
-# AppNeta TraceView Initializer (the oboe gem)
+# AppNeta TraceView Initializer (for the traceview gem)
 # http://www.appneta.com/products/traceview/
 #
 # More information on instrumenting Ruby applications can be found here:
@@ -42,7 +42,7 @@ if defined?(TraceView::Config)
   # query args by default.
   TraceView::Config[:include_remote_url_params] = true
 
-  # The oboe Ruby client has the ability to sanitize query literals
+  # The TraceView Ruby client has the ability to sanitize query literals
   # from SQL statements.  By default this is disabled.  Enable to
   # avoid collecting and reporting query literals to TraceView.
   # TraceView::Config[:sanitize_sql] = false
@@ -70,7 +70,7 @@ if defined?(TraceView::Config)
   # regardless of case
   #
   # Requests with positive matches (non nil) will not be traced.
-  # See lib/oboe/util.rb: TraceView::Util.static_asset?
+  # See lib/traceview/util.rb: TraceView::Util.static_asset?
   #
   # TraceView::Config[:dnt_regexp] = "\.(jpg|jpeg|gif|png|ico|css|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|js|flv|swf|ttf|woff|svg|less)$"
   # TraceView::Config[:dnt_opts]   = Regexp::IGNORECASE

--- a/lib/traceview/frameworks/rails.rb
+++ b/lib/traceview/frameworks/rails.rb
@@ -25,6 +25,7 @@ module TraceView
           return ""
         end
       end
+      alias_method :oboe_rum_header, :traceview_rum_header
 
       def traceview_rum_footer
         begin
@@ -39,6 +40,7 @@ module TraceView
           return ""
         end
       end
+      alias_method :oboe_rum_footer, :traceview_rum_footer
     end # Helpers
 
     def self.load_initializer

--- a/lib/traceview/frameworks/sinatra.rb
+++ b/lib/traceview/frameworks/sinatra.rb
@@ -54,6 +54,7 @@ module TraceView
         TraceView.logger.warn "traceview_rum_header: #{e.message}."
         return ''
       end
+      alias_method :oboe_rum_header, :traceview_rum_header
 
       def traceview_rum_footer
         return unless TraceView::Config.rum_id
@@ -66,6 +67,7 @@ module TraceView
         TraceView.logger.warn "traceview_rum_footer: #{e.message}."
         return ''
       end
+      alias_method :oboe_rum_footer, :traceview_rum_footer
     end
   end
 end

--- a/test/frameworks/apps/sinatra_simple.rb
+++ b/test/frameworks/apps/sinatra_simple.rb
@@ -3,6 +3,19 @@ require 'sinatra'
 class SinatraSimple < Sinatra::Base
   set :reload, true
 
+  template :layout do
+    # Use both the legacy and new RUM helper
+    # oboe_rum_header + traceview_rum_footer
+    %q{
+<html>
+  <head><%= oboe_rum_header %></head>
+  <body>
+    <%= yield %>
+    <%= traceview_rum_footer %>
+  </body>
+</html>}
+  end
+
   get "/" do
     'The magick number is: 2767356926488785838763860464013972991031534522105386787489885890443740254365!' # Change only the number!!!
   end

--- a/test/frameworks/sinatra_test.rb
+++ b/test/frameworks/sinatra_test.rb
@@ -26,5 +26,13 @@ describe Sinatra do
     r.headers.key?('X-Trace').must_equal true
     r.headers['X-Trace'].must_equal traces[8]['X-Trace']
   end
+
+  it "should have RUM code in the response" do
+    @app = SinatraSimple
+
+    r = get "/render"
+
+    (r.body =~ /tly.js/).wont_equal nil
+  end
 end
 

--- a/test/support/backcompat_test.rb
+++ b/test/support/backcompat_test.rb
@@ -2,6 +2,10 @@ require 'minitest_helper'
 
 describe "BackwardCompatibility" do
 
+  it 'should still export to Oboe::Ruby' do
+    defined?(::Oboe::Ruby).must_equal "constant"
+  end
+
   it 'should still respond to Oboe::Config' do
     @verbose = Oboe::Config[:verbose]
     @dalli_enabled = Oboe::Config[:dalli][:enabled]
@@ -55,7 +59,7 @@ describe "BackwardCompatibility" do
     validate_outer_layers(traces, 'api_test')
   end
 
-  it 'should still support Oboe.profile'do
+  it 'should still support Oboe::API.profile'do
     clear_all_traces
 
     Oboe::API.start_trace('outer_profile_test') do


### PR DESCRIPTION
* Calls to `Oboe::Ruby` should still succeed and internally be redirected to `TraceView::Ruby`.  
* Make `oboe_rum_header/footer` available.
* Update Rails initializer