### PR TITLE
Add alternate module capitalization for easiness

### DIFF
--- a/lib/traceview/base.rb
+++ b/lib/traceview/base.rb
@@ -223,3 +223,7 @@ end
 module TraceView
   extend TraceViewBase
 end
+
+# Setup an alias so we don't bug users
+# about single letter capitalization
+Traceview = TraceView

--- a/test/support/tvalias_test.rb
+++ b/test/support/tvalias_test.rb
@@ -1,0 +1,12 @@
+require 'minitest_helper'
+
+class TVAliasTest < Minitest::Test
+
+  def test_responds_various_capitalization
+    defined?(::TraceView).must_equal "constant"
+    defined?(::Traceview).must_equal "constant"
+
+    TraceView.methods.count.must_equal Traceview.methods.count
+  end
+end
+


### PR DESCRIPTION
Let's not aggravate users for calling `Traceview` instead of `TraceView`.