### PR TITLE
Mongoid update_all affected by Moped instrumenting

### DIFF
--- a/lib/traceview/inst/moped.rb
+++ b/lib/traceview/inst/moped.rb
@@ -264,15 +264,9 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
             end
 
             TraceView::API.trace('mongo', report_kvs) do
-              # original line:
-              # update_without_traceview(change, flags = nil)
-              # our supposed fix:
               update_without_traceview(change, flags)
             end
           else
-            # original line:
-            # update_without_traceview(change, flags = nil)
-            # our supposed fix:
             update_without_traceview(change, flags)
           end
         end

--- a/lib/traceview/inst/moped.rb
+++ b/lib/traceview/inst/moped.rb
@@ -264,10 +264,16 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
             end
 
             TraceView::API.trace('mongo', report_kvs) do
-              update_without_traceview(change, flags)
+              # original line:
+              update_without_traceview(change, flags = nil)
+              # our supposed fix:
+              # update_without_traceview(change, flags)
             end
           else
-            update_without_traceview(change, flags)
+            # original line:
+            update_without_traceview(change, flags = nil)
+            # our supposed fix:
+            # update_without_traceview(change, flags)
           end
         end
 

--- a/lib/traceview/inst/moped.rb
+++ b/lib/traceview/inst/moped.rb
@@ -253,7 +253,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
           end
         end
 
-        def update_with_traceview(change, flags = nil)
+        def update_with_traceview(change, flags = [])
           if TraceView.tracing? && !TraceView.tracing_layer_op?([:update_all, :upsert])
             begin
               report_kvs = extract_trace_details(:update)
@@ -265,15 +265,15 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
 
             TraceView::API.trace('mongo', report_kvs) do
               # original line:
-              update_without_traceview(change, flags = nil)
+              # update_without_traceview(change, flags = nil)
               # our supposed fix:
-              # update_without_traceview(change, flags)
+              update_without_traceview(change, flags)
             end
           else
             # original line:
-            update_without_traceview(change, flags = nil)
+            # update_without_traceview(change, flags = nil)
             # our supposed fix:
-            # update_without_traceview(change, flags)
+            update_without_traceview(change, flags)
           end
         end
 

--- a/lib/traceview/inst/moped.rb
+++ b/lib/traceview/inst/moped.rb
@@ -264,10 +264,10 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
             end
 
             TraceView::API.trace('mongo', report_kvs) do
-              update_without_traceview(change)
+              update_without_traceview(change, flags)
             end
           else
-            update_without_traceview(change)
+            update_without_traceview(change, flags)
           end
         end
 

--- a/lib/traceview/inst/moped.rb
+++ b/lib/traceview/inst/moped.rb
@@ -253,7 +253,7 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
           end
         end
 
-        def update_with_traceview(change, flags = [])
+        def update_with_traceview(change, flags = nil)
           if TraceView.tracing? && !TraceView.tracing_layer_op?([:update_all, :upsert])
             begin
               report_kvs = extract_trace_details(:update)

--- a/lib/traceview/inst/moped.rb
+++ b/lib/traceview/inst/moped.rb
@@ -264,10 +264,10 @@ if defined?(::Moped) && TraceView::Config[:moped][:enabled]
             end
 
             TraceView::API.trace('mongo', report_kvs) do
-              update_without_traceview(change, flags = nil)
+              update_without_traceview(change)
             end
           else
-            update_without_traceview(change, flags = nil)
+            update_without_traceview(change)
           end
         end
 

--- a/test/instrumentation/moped_test.rb
+++ b/test/instrumentation/moped_test.rb
@@ -259,16 +259,11 @@ if RUBY_VERSION >= '1.9.3'
 
       tool_count = @users.find(:name => "Tool").count
       tool_count.must_equal 0
+
       TraceView::API.start_trace('moped_test', '', {}) do
-        # TODO: remove me:
-        # Proposed new lines:
         old_attrs = { :name => "Mary" }
         new_attrs = { :name => "Tool" }
         @users.find(old_attrs).update({ '$set' => new_attrs }, { :multi => true })
-
-        # TODO: remove me:
-        # Old line:
-        # @users.find(:name => "Mary").update({:name => "Tool"}, [:multi])
       end
 
       new_tool_count = @users.find(:name => "Tool").count
@@ -291,7 +286,7 @@ if RUBY_VERSION >= '1.9.3'
 
       validate_event_keys(traces[3], @entry_kvs)
       traces[3]['QueryOp'].must_equal "update"
-      traces[3]['Update_Document'].must_equal "{\"name\":\"Tool\"}"
+      traces[3]['Update_Document'].must_equal "{\"$set\":{\"name\":\"Tool\"}}"
       traces[3]['Flags'].must_equal "{:multi=>true}"
       traces[3]['Collection'].must_equal "users"
       traces[3].has_key?('Backtrace').must_equal TraceView::Config[:moped][:collect_backtraces]

--- a/test/instrumentation/moped_test.rb
+++ b/test/instrumentation/moped_test.rb
@@ -9,6 +9,7 @@ if RUBY_VERSION >= '1.9.3'
       @session = Moped::Session.new([ "127.0.0.1:27017" ])
       @session.use :moped_test
       @users = @session[:users]
+      @users.drop
       @users.insert({ :name => "Syd", :city => "Boston" })
 
       # These are standard entry/exit KVs that are passed up with all moped operations

--- a/test/instrumentation/moped_test.rb
+++ b/test/instrumentation/moped_test.rb
@@ -259,21 +259,25 @@ if RUBY_VERSION >= '1.9.3'
       tool_count = @users.find(:name => "Tool").count
       tool_count.must_equal 0
       TraceView::API.start_trace('moped_test', '', {}) do
+        # TODO: remove me:
         # Proposed new lines:
         old_attrs = { :name => "Mary" }
         new_attrs = { :name => "Tool" }
         @users.find(old_attrs).update({ '$set' => new_attrs }, { :multi => true })
 
+        # TODO: remove me:
         # Old line:
-        @users.find(:name => "Mary").update({:name => "Tool"}, [:multi])
+        # @users.find(:name => "Mary").update({:name => "Tool"}, [:multi])
       end
 
       new_tool_count = @users.find(:name => "Tool").count
       new_tool_count.must_equal mary_count
 
       traces = get_all_traces
+      # TODO: remove me
+      puts traces.inspect
 
-      traces.count.must_equal 6
+      traces.count.must_equal 10
       validate_outer_layers(traces, 'moped_test')
 
       validate_event_keys(traces[1], @entry_kvs)
@@ -286,7 +290,7 @@ if RUBY_VERSION >= '1.9.3'
       validate_event_keys(traces[3], @entry_kvs)
       traces[3]['QueryOp'].must_equal "update"
       traces[3]['Update_Document'].must_equal "{\"name\":\"Tool\"}"
-      traces[3]['Flags'].must_equal "[:multi]"
+      traces[3]['Flags'].must_equal "{:multi=>true}"
       traces[3]['Collection'].must_equal "users"
       traces[3].has_key?('Backtrace').must_equal TraceView::Config[:moped][:collect_backtraces]
       validate_event_keys(traces[4], @exit_kvs)

--- a/test/instrumentation/moped_test.rb
+++ b/test/instrumentation/moped_test.rb
@@ -275,7 +275,7 @@ if RUBY_VERSION >= '1.9.3'
       new_tool_count.must_equal mary_count
 
       new_mary_count = @users.find(:name => "Mary").count
-      new_mary_count.must_equal = 0
+      new_mary_count.must_equal 0
 
       traces = get_all_traces
       # TODO: remove me

--- a/test/instrumentation/moped_test.rb
+++ b/test/instrumentation/moped_test.rb
@@ -278,10 +278,8 @@ if RUBY_VERSION >= '1.9.3'
       new_mary_count.must_equal 0
 
       traces = get_all_traces
-      # TODO: remove me
-      puts traces.inspect
 
-      traces.count.must_equal 10
+      traces.count.must_equal 6
       validate_outer_layers(traces, 'moped_test')
 
       validate_event_keys(traces[1], @entry_kvs)

--- a/test/instrumentation/moped_test.rb
+++ b/test/instrumentation/moped_test.rb
@@ -254,9 +254,17 @@ if RUBY_VERSION >= '1.9.3'
     it 'should trace find and update' do
       2.times { @users.insert(:name => "Mary") }
       mary_count = @users.find(:name => "Mary").count
+      mary_count.wont_equal 0
+
       tool_count = @users.find(:name => "Tool").count
       tool_count.must_equal 0
       TraceView::API.start_trace('moped_test', '', {}) do
+        # Proposed new lines:
+        old_attrs = { :name => "Mary" }
+        new_attrs = { :name => "Tool" }
+        @users.find(old_attrs).update({ '$set' => new_attrs }, { :multi => true })
+
+        # Old line:
         @users.find(:name => "Mary").update({:name => "Tool"}, [:multi])
       end
 

--- a/test/instrumentation/moped_test.rb
+++ b/test/instrumentation/moped_test.rb
@@ -278,9 +278,15 @@ if RUBY_VERSION >= '1.9.3'
     end
 
     it 'should trace find and update_all' do
+      @users.insert(:name => "Mary")
+      mary_count = @users.find(:name => "Mary").count
+      tool_count = @users.find(:name => "Tool").count
+      tool_count.must_equal 0
+
       TraceView::API.start_trace('moped_test', '', {}) do
         @users.find(:name => "Mary").update_all({:name => "Tool"})
       end
+      new_tool_count.must_equal mary_count
 
       traces = get_all_traces
 
@@ -298,6 +304,7 @@ if RUBY_VERSION >= '1.9.3'
       traces[3]['QueryOp'].must_equal "update_all"
       traces[3]['Update_Document'].must_equal "{\"name\":\"Tool\"}"
       traces[3]['Collection'].must_equal "users"
+      traces[3]['Flags'].must_equal "[:multi]"
       traces[3].has_key?('Backtrace').must_equal TraceView::Config[:moped][:collect_backtraces]
       validate_event_keys(traces[4], @exit_kvs)
     end

--- a/test/instrumentation/moped_test.rb
+++ b/test/instrumentation/moped_test.rb
@@ -273,6 +273,9 @@ if RUBY_VERSION >= '1.9.3'
       new_tool_count = @users.find(:name => "Tool").count
       new_tool_count.must_equal mary_count
 
+      new_mary_count = @users.find(:name => "Mary").count
+      new_mary_count.must_equal = 0
+
       traces = get_all_traces
       # TODO: remove me
       puts traces.inspect


### PR DESCRIPTION
Howdy!

My team recently started using TraceView in a web application which uses Rails 4 and Mongoid 4. Since including the gem in the project, we noticed a change in behavior when using the `update_all` method on a Mongoid model:

```ruby
# Taking the example from the test (is it a reference to the band..?) :)
User.where(name: "Mary").count #=> 5
User.where(name: "Tool").count #=> 0
User.where(name: "Mary").update_all(name: "Tool")
User.where(name: "Mary").count #=> 4
User.where(name: "Tool").count #=> 1
```

After a little digging (watching some Moped logging output was ultimately the most helpful clue), we observed that in our earlier code, `update_all` was translated to a moped `update` with a flag of `[:multi]`. In our newer code, after including oboe, it was the same -- but **without the `[:multi]` flag**. Omitting the multi flag does lead to the behavior described in that code example, so that seems related.

It seems like oboe is passing the flags through several methods, but at one point, it passes `nil` instead of the flags, so when oboe asks Moped to resume the query, it does so without the flags it needs to do the right thing. Does that make sense? I'm not super intimately familiar with this code. Feel free to spin us around and point us in the right direction if we're barking up the wrong tree :smile:.

I've edited the test to describe the behavior we're hoping for. I wasn't able to get them running locally, so I'm not sure if it passes. I'm going to go to sleep and check in with Travis in the morning :smile:.