### PR TITLE
Rails generator broken after gem rename

### DIFF
--- a/lib/rails/generators/traceview/install_generator.rb
+++ b/lib/rails/generators/traceview/install_generator.rb
@@ -6,6 +6,8 @@ module TraceView
     source_root File.join(File.dirname(__FILE__), 'templates')
     desc "Copies a TraceView gem initializer file to your application."
 
+    @namespace = "traceview:install"
+
     def copy_initializer
       # Set defaults
       @tracing_mode = 'through'


### PR DESCRIPTION
Title says it all.  Error message is "generator not found".

![screenshot 2015-06-26 22 00 27](https://cloud.githubusercontent.com/assets/395132/8386202/c3c52226-1c4e-11e5-8262-c7db4b42dcf3.png)
