### PR TITLE
Fix set to work with array versus hash

### DIFF
--- a/lib/traceview/inst/redis.rb
+++ b/lib/traceview/inst/redis.rb
@@ -228,7 +228,7 @@ module TraceView
 
             begin
               r = call_without_traceview(command, &block)
-              report_kvs = extract_trace_details(command.dup, r)
+              report_kvs = extract_trace_details(command, r)
               r
             rescue StandardError => e
               ::TraceView::API.log_exception('redis', e)

--- a/test/instrumentation/redis_strings_test.rb
+++ b/test/instrumentation/redis_strings_test.rb
@@ -268,7 +268,7 @@ if defined?(::Redis)
 
     it "should trace set + expiration" do
       TraceView::API.start_trace('redis_test', '', {}) do
-        @redis.set("one", "hello", ex: 12)
+        @redis.set("one", "hello", :ex => 12)
       end
 
       traces = get_all_traces

--- a/test/instrumentation/redis_strings_test.rb
+++ b/test/instrumentation/redis_strings_test.rb
@@ -266,6 +266,18 @@ if defined?(::Redis)
       traces[2]['KVKey'].must_equal "one"
     end
 
+    it "should trace set + expiration" do
+      TraceView::API.start_trace('redis_test', '', {}) do
+        @redis.set("one", "hello", ex: 12)
+      end
+
+      traces = get_all_traces
+      traces.count.must_equal 4
+      traces[2]['KVOp'].must_equal "set"
+      traces[2]['KVKey'].must_equal "one"
+      traces[2][:ex].must_equal 12
+    end
+
     it "should trace setbit" do
       min_server_version(2.2)
 


### PR DESCRIPTION
When using the redis integration, `command` was only a list of strings and symbols and didn't have a nested hash, so this was blowing up.  As far back as I can see, it didn't populate a hash so I think we'd be safe just assuming an array here, but I left the old code in case it worked with older versions.