### PR TITLE
undefined method `request_without_traceview' for #<HTTPClient:0x0000000c9916a8>

### DIFF
--- a/lib/traceview/inst/httpclient.rb
+++ b/lib/traceview/inst/httpclient.rb
@@ -38,7 +38,7 @@ module TraceView
       def do_request_with_traceview(method, uri, query, body, header, &block)
         # If we're not tracing, just do a fast return.
         if !TraceView.tracing?
-          return request_without_traceview(method, uri, query, body, header, &block)
+          return do_request_without_traceview(method, uri, query, body, header, &block)
         end
 
         begin

--- a/test/instrumentation/httpclient_test.rb
+++ b/test/instrumentation/httpclient_test.rb
@@ -295,5 +295,28 @@ class HTTPClientTest < Minitest::Test
 
     TraceView::Config[:httpclient][:log_args] = @log_args
   end
+
+  def test_without_tracing
+    clear_all_traces
+
+    @tm = TraceView::Config[:tracing_mode]
+    TraceView::Config[:tracing_mode] = :never
+
+    response = nil
+
+    TraceView::API.start_trace('httpclient_tests') do
+      clnt = HTTPClient.new
+      response = clnt.get('http://127.0.0.1:8101/', :query => { :keyword => 'ruby', :lang => 'en' })
+    end
+
+    xtrace = response.headers['X-Trace']
+    assert xtrace == nil
+
+    traces = get_all_traces
+
+    assert_equal traces.count, 0
+
+    TraceView::Config[:tracing_mode] = @tm
+  end
 end
 


### PR DESCRIPTION
is there a workaround for this? 
I think there should be "execute_without_traceview" instead of "request_without_traceview". 

Here is some backtrace:

```
traceview (3.0.4) lib/traceview/inst/httpclient.rb:41:in `do_request_with_traceview'
httpclient (2.6.0.1) lib/httpclient.rb:822:in `request'
httpi (2.4.0) lib/httpi/adapter/httpclient.rb:26:in `request'
httpi (2.4.0) lib/httpi.rb:160:in `request'
httpi (2.4.0) lib/httpi.rb:132:in `post'
savon (2.11.1) lib/savon/operation.rb:94:in `block in call_with_logging'
savon (2.11.1) lib/savon/request_logger.rb:12:in `call'
savon (2.11.1) lib/savon/request_logger.rb:12:in `log'
savon (2.11.1) lib/savon/operation.rb:94:in `call_with_logging'
savon (2.11.1) lib/savon/operation.rb:54:in `call'
savon (2.11.1) lib/savon/client.rb:36:in `call'
```

Would be really great if this could be fixed. Thanks