### PR TITLE
Instrument Curb 

### DIFF
--- a/gemfiles/libraries.gemfile
+++ b/gemfiles/libraries.gemfile
@@ -43,17 +43,18 @@ else
   gem 'sinatra'
 end
 
-gem 'dalli'
-gem 'memcache-client'
 gem 'cassandra'
-gem 'mongo'
-gem 'resque'
-gem 'redis'
+gem 'curb'
+gem 'dalli'
+gem 'excon'
 gem 'faraday'
 gem 'httpclient'
-gem 'excon'
-gem 'typhoeus'
+gem 'memcache-client'
+gem 'mongo'
+gem 'redis'
+gem 'resque'
 gem 'sequel'
+gem 'typhoeus'
 
 # Database adapter gems needed by sequel
 if defined?(JRUBY_VERSION)

--- a/lib/oboe_metal.rb
+++ b/lib/oboe_metal.rb
@@ -1,6 +1,8 @@
 # Copyright (c) 2013 AppNeta, Inc.
 # All rights reserved.
 
+require 'thread'
+
 # Disable docs and Camelcase warns since we're implementing
 # an interface here.  See OboeBase for details.
 # rubocop:disable Style/Documentation, Style/MethodName
@@ -149,3 +151,4 @@ end
 # rubocop:enable Style/Documentation
 
 TraceView.loaded = true
+TraceView.config_lock = Mutex.new

--- a/lib/rails/generators/traceview/templates/traceview_initializer.rb
+++ b/lib/rails/generators/traceview/templates/traceview_initializer.rb
@@ -97,6 +97,7 @@ if defined?(TraceView::Config)
   # TraceView::Config[:active_record][:enabled] = true
   # TraceView::Config[:action_view][:enabled] = true
   # TraceView::Config[:cassandra][:enabled] = true
+  # TraceView::Config[:curb][:enabled] = true
   # TraceView::Config[:dalli][:enabled] = true
   # TraceView::Config[:excon][:enabled] = true
   # TraceView::Config[:em_http_request][:enabled] = true
@@ -126,6 +127,7 @@ if defined?(TraceView::Config)
   # TraceView::Config[:active_record][:collect_backtraces] = true
   # TraceView::Config[:action_view][:collect_backtraces] = true
   # TraceView::Config[:cassandra][:collect_backtraces] = true
+  # TraceView::Config[:curb][:collect_backtraces] = true
   # TraceView::Config[:dalli][:collect_backtraces] = false
   # TraceView::Config[:excon][:collect_backtraces] = false
   # TraceView::Config[:em_http_request][:collect_backtraces] = true
@@ -142,6 +144,22 @@ if defined?(TraceView::Config)
   # TraceView::Config[:sequel][:collect_backtraces] = true
   # TraceView::Config[:typhoeus][:collect_backtraces] = false
   #
+
+  # By default, the curb instrumentation will not link
+  # outgoing requests with remotely instrumented
+  # webservers (aka cross host tracing).  This is because the
+  # instrumentation can't detect if the independent libcurl
+  # instrumentation is in use or not.
+  #
+  # If you're sure that it's not in use/installed, then you can
+  # enable cross host tracing for the curb HTTP client
+  # here.  Set TraceView::Config[:curb][:cross_host] to true
+  # to enable.
+  #
+  # Alternatively, if you would like to install the separate
+  # libcurl instrumentation, see here:
+  # http://docs.appneta.com/installing-libcurl-instrumentation
+  # TraceView::Config[:curb][:cross_host] = false
 
   #
   # Resque Options

--- a/lib/traceview/base.rb
+++ b/lib/traceview/base.rb
@@ -251,3 +251,4 @@ end
 # Setup an alias so we don't bug users
 # about single letter capitalization
 Traceview = TraceView
+TV = TraceView

--- a/lib/traceview/base.rb
+++ b/lib/traceview/base.rb
@@ -192,6 +192,30 @@ module TraceViewBase
   end
 
   ##
+  # Debugging helper method
+  #
+  def pry!
+    # Only valid for development or test environments
+    env = ENV['RACK_ENV'] || ENV['RAILS_ENV']
+    return unless [ "development", "test" ].include? env
+
+    require 'pry-byebug'
+
+    if defined?(PryByebug)
+      Pry.commands.alias_command 'c', 'continue'
+      Pry.commands.alias_command 's', 'step'
+      Pry.commands.alias_command 'n', 'next'
+      Pry.commands.alias_command 'f', 'finish'
+
+      Pry::Commands.command /^$/, "repeat last command" do
+        _pry_.run_command Pry.history.to_a.last
+      end
+    end
+
+    binding.pry
+  end
+
+  ##
   # Indicates whether a supported framework is in use
   # or not
   #

--- a/lib/traceview/base.rb
+++ b/lib/traceview/base.rb
@@ -35,6 +35,9 @@ module TraceViewBase
   thread_local :sample_rate
   thread_local :layer
   thread_local :layer_op
+  # Semaphore used during the test suite to test
+  # global config options.
+  thread_local :config_lock
 
   # The following accessors indicate the incoming tracing state received
   # by the rack layer.  These are primarily used to identify state

--- a/lib/traceview/base.rb
+++ b/lib/traceview/base.rb
@@ -202,20 +202,24 @@ module TraceViewBase
     env = ENV['RACK_ENV'] || ENV['RAILS_ENV']
     return unless [ "development", "test" ].include? env
 
-    require 'pry-byebug'
+    if RUBY_VERSION > '1.8.7'
+      require 'pry-byebug'
 
-    if defined?(PryByebug)
-      Pry.commands.alias_command 'c', 'continue'
-      Pry.commands.alias_command 's', 'step'
-      Pry.commands.alias_command 'n', 'next'
-      Pry.commands.alias_command 'f', 'finish'
+      if defined?(PryByebug)
+        Pry.commands.alias_command 'c', 'continue'
+        Pry.commands.alias_command 's', 'step'
+        Pry.commands.alias_command 'n', 'next'
+        Pry.commands.alias_command 'f', 'finish'
 
-      Pry::Commands.command /^$/, "repeat last command" do
-        _pry_.run_command Pry.history.to_a.last
+        Pry::Commands.command /^$/, "repeat last command" do
+          _pry_.run_command Pry.history.to_a.last
+        end
       end
-    end
 
-    binding.pry
+      binding.pry
+    else
+      require 'ruby-debug'; debugger
+    end
   end
 
   ##

--- a/lib/traceview/config.rb
+++ b/lib/traceview/config.rb
@@ -12,13 +12,13 @@ module TraceView
     @@config = {}
 
     @@instrumentation = [:action_controller, :action_view, :active_record,
-                         :cassandra, :dalli, :em_http_request, :excon, :faraday,
+                         :cassandra, :curb, :dalli, :em_http_request, :excon, :faraday,
                          :grape, :httpclient, :nethttp, :memcached, :memcache, :mongo,
                          :moped, :rack, :redis, :resque, :rest_client, :sequel,
                          :typhoeus]
 
     # Subgrouping of instrumentation
-    @@http_clients = [:excon, :faraday, :httpclient, :nethttp, :rest_client, :typhoeus]
+    @@http_clients = [:curb, :excon, :faraday, :httpclient, :nethttp, :rest_client, :typhoeus]
 
     ##
     # Return the raw nested hash.
@@ -44,6 +44,7 @@ module TraceView
       TraceView::Config[:active_record][:collect_backtraces] = true
       TraceView::Config[:action_view][:collect_backtraces] = true
       TraceView::Config[:cassandra][:collect_backtraces] = true
+      TraceView::Config[:curb][:collect_backtraces] = true
       TraceView::Config[:dalli][:collect_backtraces] = false
       TraceView::Config[:em_http_request][:collect_backtraces] = false
       TraceView::Config[:excon][:collect_backtraces] = true

--- a/lib/traceview/config.rb
+++ b/lib/traceview/config.rb
@@ -147,6 +147,15 @@ module TraceView
       # report all raised exception regardless.
       @@config[:report_rescued_errors] = false
 
+      # By default, the curb instrumentation will not link
+      # outgoing requests with remotely instrumented
+      # webservers (cross host tracing).  This is because at it's
+      # core, curb could be using the TraceView libcurl instrumentation
+      # which unfortunately it cannot detect.  If you're sure this is not
+      # the case, you can enable cross host tracing for the curb HTTP client
+      # here.  Set to true to enable.
+      @@config[:curb][:cross_host] = false
+
       # Environment support for OpenShift.
       if ENV.key?('OPENSHIFT_TRACEVIEW_TLYZER_IP')
         # We're running on OpenShift

--- a/lib/traceview/config.rb
+++ b/lib/traceview/config.rb
@@ -149,13 +149,17 @@ module TraceView
 
       # By default, the curb instrumentation will not link
       # outgoing requests with remotely instrumented
-      # webservers (cross host tracing).  This is because at it's
-      # core, curb could be using the TraceView libcurl instrumentation
-      # which unfortunately it cannot detect.  If you're sure this is not
-      # the case, you can enable cross host tracing for the curb HTTP client
-      # here.  Set to true to enable.
+      # webservers (aka cross host tracing).  This is because the
+      # instrumentation can't detect if the independent libcurl
+      # instrumentation is in use or not.
       #
-      # To install the TraceView libcurl instrumentation, see here:
+      # If you're sure that it's not in use/installed, then you can
+      # enable cross host tracing for the curb HTTP client
+      # here.  Set TraceView::Config[:curb][:cross_host] to true
+      # to enable.
+      #
+      # Alternatively, if you would like to install the separate
+      # libcurl instrumentation, see here:
       # http://docs.appneta.com/installing-libcurl-instrumentation
       @@config[:curb][:cross_host] = false
 

--- a/lib/traceview/config.rb
+++ b/lib/traceview/config.rb
@@ -154,6 +154,9 @@ module TraceView
       # which unfortunately it cannot detect.  If you're sure this is not
       # the case, you can enable cross host tracing for the curb HTTP client
       # here.  Set to true to enable.
+      #
+      # To install the TraceView libcurl instrumentation, see here:
+      # http://docs.appneta.com/installing-libcurl-instrumentation
       @@config[:curb][:cross_host] = false
 
       # Environment support for OpenShift.

--- a/lib/traceview/inst/curb.rb
+++ b/lib/traceview/inst/curb.rb
@@ -164,11 +164,11 @@ module TraceView
       #
       # ::Curl::Easy.new.http wrapper
       #
-      def http_with_traceview(verb)
+      def http_with_traceview(verb, &block)
         # If we're not tracing, just do a fast return.
         return http_without_traceview(verb) if !TraceView.tracing?
 
-        profile_curb_method({ :HTTPMethod => verb }, :http_without_traceview, [verb])
+        profile_curb_method({ :HTTPMethod => verb }, :http_without_traceview, [verb], &block)
       end
     end
 

--- a/lib/traceview/inst/curb.rb
+++ b/lib/traceview/inst/curb.rb
@@ -3,12 +3,19 @@
 
 module TraceView
   module Inst
-    module CurlEasy
-      def self.included(klass)
-        ::TraceView::Util.method_alias(klass, :perform, ::Curl::Easy)
-      end
 
-      def traceview_collect
+    # Curb instrumentation wraps instance and class methods in three classes: Curl,
+    # Curl::Easy and Curl::Multi.  This CurlUtility module is used as a common module
+    # to be shared among all three Curl modules
+    module CurlUtility
+
+      ##
+      # traceview_collect
+      #
+      # Used as a central area to retrieve and return values
+      # that we're interesting in reporting to TraceView
+      #
+      def traceview_collect(url, verb = nil)
         kvs = {}
         kvs['IsService'] = 1
 
@@ -19,7 +26,13 @@ module TraceView
           kvs[:RemoteURL] = url.split('?').first
         end
 
-        # kvs['HTTPMethod'] = ::TraceView::Util.upcase(params[:method])
+        kvs[:HTTPMethod] = verb if verb
+
+        # Avoid cross host tracing for blacklisted domains
+        if TraceView::API.blacklisted?(URI(url).hostname)
+          kvs['Blacklisted'] = true
+        end
+
         kvs['Backtrace'] = TraceView::API.backtrace if TraceView::Config[:curb][:collect_backtraces]
         kvs
       rescue => e
@@ -27,21 +40,108 @@ module TraceView
         TraceView.logger.debug e.backtrace.join('\n') if ::TraceView::Config[:verbose]
       end
 
+      ##
+      # profile_curb_method
+      #
+      # An agnostic method that will profile any method (and optional args and block)
+      # that you throw at it.
+      #
+      def profile_curb_method(kvs, method, args, &block)
+        # If we're not tracing, just do a fast return.
+        return self.send(method, args, &block) if !TraceView.tracing?
+
+        begin
+          handle_cross_host = TraceView::Config[:curb][:cross_host]
+
+          if handle_cross_host
+            # We're getting call here from Curl class methods, Curl::Easy class _and_
+            # instance methods and then there is also Curl::Multi.  Try to handle all
+            # as elegantly as possibile.
+            if self == ::Curl
+              handle = Thread.current[:curb_curl] ||= Curl::Easy.new
+            else
+              handle = self
+            end
+            req_context = TraceView::Context.toString()
+            handle.headers['X-Trace'] = req_context unless kvs[:Blacklisted]
+            Thread.current[:curb_curl] = handle if handle.is_a?(::Curl::Easy)
+          end
+
+          TraceView::API.log_entry('curb', kvs)
+
+          # The core call
+          response = self.send(method, *args, &block)
+
+          if [TrueClass, FalseClass].include?(response.class)
+            easy = self
+          else
+            easy = response
+          end
+
+          kvs = { :HTTPStatus => easy.response_code }
+
+          # If we get a redirect, report the location header
+          if ((300..308).to_a.include? kvs[:HTTPStatus]) && easy.headers.key?("Location")
+            kvs[:Location] = easy.headers["Location"]
+          end
+
+          if handle_cross_host && easy.headers['X-Trace'] && !kvs[:Blacklisted]
+            TraceView::XTrace.continue_service_context(req_context, easy.headers['X-Trace'])
+          end
+
+          response
+        rescue => e
+          TraceView::API.log_exception('curb', e)
+          raise e
+        ensure
+          TraceView::API.log_exit('curb', kvs)
+        end
+      end
+    end # CurlUtility
+
+    # Instrumentation specific to ::Curl::Easy
+    module CurlEasy
+      # Common methods
+      include TraceView::Inst::CurlUtility
+
+      def self.included(klass)
+        ::TraceView::Util.method_alias(klass, :http, ::Curl::Easy)
+        ::TraceView::Util.method_alias(klass, :perform, ::Curl::Easy)
+      end
+
+      ##
+      # perform_with_traceview
+      #
+      # ::Curl::Easy.new.perform wrapper
+      #
       def perform_with_traceview
         # If we're not tracing, just do a fast return.
-        return perform_without_traceview if !TraceView.tracing?
+        if !TraceView.tracing? || TraceView.tracing_layer?('curb')
+          return perform_without_traceview
+        end
 
         begin
           response_context = nil
+          handle_cross_host = TraceView::Config[:curb][:cross_host]
+          kvs = traceview_collect(url)
 
-          # Avoid cross host tracing for blacklisted domains
-          blacklisted = TraceView::API.blacklisted?(URI(url).hostname)
+          # This perform gets called from two places, ::Curl::Easy.new.perform
+          # and Curl::Easy.new.http_head. In the case of http_head we detect the
+          # HTTP verb via get info.
+          if self.getinfo(self.sym2curl(:nobody))
+            kvs[:HTTPMethod] = :HEAD
+          else
+            kvs[:HTTPMethod] = :GET
+          end
 
-          req_context = TraceView::Context.toString()
-          self.headers['X-Trace'] = req_context unless blacklisted
+          if handle_cross_host
+            # Avoid cross host tracing for blacklisted domains
+            blacklisted = TraceView::API.blacklisted?(URI(url).hostname)
 
-          kvs = traceview_collect
-          kvs['Blacklisted'] = true if blacklisted
+            req_context = TraceView::Context.toString()
+            self.headers['X-Trace'] = req_context unless blacklisted
+            kvs['Blacklisted'] = true if blacklisted
+          end
 
           TraceView::API.log_entry('curb', kvs)
           kvs.clear
@@ -49,8 +149,59 @@ module TraceView
           # The core curb call
           response = perform_without_traceview
 
-          if response
+          kvs['HTTPStatus'] = response_code
+
+          # If we get a redirect, report the location header
+          if ((300..308).to_a.include? response_code) && headers.key?("Location")
+            kvs["Location"] = headers["Location"]
+          end
+
+          if handle_cross_host
             response_context = headers['X-Trace']
+            if response_context && !blacklisted
+              TraceView::XTrace.continue_service_context(req_context, response_context)
+            end
+          end
+
+          response
+        rescue => e
+          TraceView::API.log_exception('curb', e)
+          raise e
+        ensure
+          TraceView::API.log_exit('curb', kvs)
+        end
+      end
+
+      ##
+      # http_with_traceview
+      #
+      # ::Curl::Easy.new.http wrapper
+      #
+      def http_with_traceview(verb)
+        # If we're not tracing, just do a fast return.
+        return http_without_traceview(verb) if !TraceView.tracing?
+
+        begin
+          response_context = nil
+          handle_cross_host = TraceView::Config[:curb][:cross_host]
+          kvs = traceview_collect(url, verb)
+
+          if handle_cross_host
+            # Avoid cross host tracing for blacklisted domains
+            blacklisted = TraceView::API.blacklisted?(URI(url).hostname)
+
+            req_context = TraceView::Context.toString()
+            self.headers['X-Trace'] = req_context unless blacklisted
+            kvs['Blacklisted'] = true if blacklisted
+          end
+
+          TraceView::API.log_entry('curb', kvs)
+          kvs.clear
+
+          # The core curb call
+          response = http_without_traceview(verb)
+
+          if response
             kvs['HTTPStatus'] = response_code
 
             # If we get a redirect, report the location header
@@ -58,8 +209,11 @@ module TraceView
               kvs["Location"] = headers["Location"]
             end
 
-            if response_context && !blacklisted
-              TraceView::XTrace.continue_service_context(req_context, response_context)
+            if handle_cross_host
+              response_context = headers['X-Trace']
+              if response_context && !blacklisted
+                TraceView::XTrace.continue_service_context(req_context, response_context)
+              end
             end
           else
             # The call returned false; error
@@ -75,10 +229,47 @@ module TraceView
         end
       end
     end
+
+    module CurlMulti
+      # Common methods
+      include TraceView::Inst::CurlUtility
+
+      def self.extended(klass)
+        ::TraceView::Util.class_method_alias(klass, :http, ::Curl::Multi)
+      end
+
+      ##
+      # http_with_traceview
+      #
+      # ::Curl::Multi.new.http wrapper
+      #
+      def http_with_traceview(urls_with_config, multi_options={}, &blk)
+        # If we're not tracing, just do a fast return.
+        if !TraceView.tracing?
+          return http_without_traceview(urls_with_config, multi_options={}, &blk)
+        end
+
+        begin
+          kvs = {}
+
+          TraceView::API.log_entry('curb_multi', kvs)
+          kvs.clear
+
+          # The core curb call
+          http_without_traceview(urls_with_config, multi_options, &blk)
+        rescue => e
+          TraceView::API.log_exception('curb_multi', e)
+          raise e
+        ensure
+          TraceView::API.log_exit('curb_multi', kvs)
+        end
+      end
+    end
   end
 end
 
-if TraceView::Config[:curb][:enabled] && defined?(::Curl::Easy)
+if TraceView::Config[:curb][:enabled] && defined?(::Curl)
   ::TraceView.logger.info '[traceview/loading] Instrumenting curb' if TraceView::Config[:verbose]
   ::TraceView::Util.send_include(::Curl::Easy, ::TraceView::Inst::CurlEasy)
+  ::TraceView::Util.send_extend(::Curl::Multi, ::TraceView::Inst::CurlMulti)
 end

--- a/lib/traceview/inst/curb.rb
+++ b/lib/traceview/inst/curb.rb
@@ -1,0 +1,84 @@
+# Copyright (c) 2015 AppNeta, Inc.
+# All rights reserved.
+
+module TraceView
+  module Inst
+    module CurlEasy
+      def self.included(klass)
+        ::TraceView::Util.method_alias(klass, :perform, ::Curl::Easy)
+      end
+
+      def traceview_collect
+        kvs = {}
+        kvs['IsService'] = 1
+
+        # Conditionally log query args
+        if TraceView::Config[:curb][:log_args]
+          kvs[:RemoteURL] = url
+        else
+          kvs[:RemoteURL] = url.split('?').first
+        end
+
+        # kvs['HTTPMethod'] = ::TraceView::Util.upcase(params[:method])
+        kvs['Backtrace'] = TraceView::API.backtrace if TraceView::Config[:curb][:collect_backtraces]
+        kvs
+      rescue => e
+        TraceView.logger.debug "[traceview/debug] Error capturing curb KVs: #{e.message}"
+        TraceView.logger.debug e.backtrace.join('\n') if ::TraceView::Config[:verbose]
+      end
+
+      def perform_with_traceview
+        # If we're not tracing, just do a fast return.
+        return perform_without_traceview if !TraceView.tracing?
+
+        begin
+          response_context = nil
+
+          # Avoid cross host tracing for blacklisted domains
+          blacklisted = TraceView::API.blacklisted?(URI(url).hostname)
+
+          req_context = TraceView::Context.toString()
+          self.headers['X-Trace'] = req_context unless blacklisted
+
+          kvs = traceview_collect
+          kvs['Blacklisted'] = true if blacklisted
+
+          TraceView::API.log_entry('curb', kvs)
+          kvs.clear
+
+          # The core curb call
+          response = perform_without_traceview
+
+          if response
+            response_context = headers['X-Trace']
+            kvs['HTTPStatus'] = response_code
+
+            # If we get a redirect, report the location header
+            if ((300..308).to_a.include? response_code) && headers.key?("Location")
+              kvs["Location"] = headers["Location"]
+            end
+
+            if response_context && !blacklisted
+              TraceView::XTrace.continue_service_context(req_context, response_context)
+            end
+          else
+            # The call returned false; error
+            require 'byebug'; debugger
+          end
+
+          response
+        rescue => e
+          TraceView::API.log_exception('curb', e)
+          raise e
+        ensure
+          TraceView::API.log_exit('curb', kvs)
+        end
+      end
+    end
+  end
+end
+
+if TraceView::Config[:curb][:enabled] && defined?(::Curl::Easy)
+  ::TraceView.logger.info '[traceview/loading] Instrumenting curb' if TraceView::Config[:verbose]
+  ::TraceView::Util.send_include(::Curl::Easy, ::TraceView::Inst::CurlEasy)
+end

--- a/lib/traceview/inst/curb.rb
+++ b/lib/traceview/inst/curb.rb
@@ -333,7 +333,7 @@ module TraceView
   end
 end
 
-if TraceView::Config[:curb][:enabled] && defined?(::Curl)
+if TraceView::Config[:curb][:enabled] && defined?(::Curl) && RUBY_VERSION > '1.8.7'
   ::TraceView.logger.info '[traceview/loading] Instrumenting curb' if TraceView::Config[:verbose]
   ::TraceView::Util.send_include(::Curl::Easy, ::TraceView::Inst::CurlEasy)
   ::TraceView::Util.send_extend(::Curl::Multi, ::TraceView::Inst::CurlMultiCM)

--- a/lib/traceview/instrumentation.rb
+++ b/lib/traceview/instrumentation.rb
@@ -14,6 +14,7 @@ module TraceView
           require f
         rescue => e
           TraceView.logger.error "[traceview/loading] Error loading instrumentation file '#{f}' : #{e}"
+          TraceView.logger.debug "[traceview/loading] #{e.backtrace.first}"
         end
       end
     end

--- a/lib/traceview/util.rb
+++ b/lib/traceview/util.rb
@@ -205,6 +205,7 @@ module TraceView
 
           # Report the instrumented libraries
           platform_info['Ruby.Cassandra.Version']  = "Cassandra-#{::Cassandra.VERSION}"    if defined?(::Cassandra.VERSION)
+          platform_info['Ruby.Curb.Version']       = "Curb-#{::Curl::VERSION}"             if defined?(::Curl::VERSION)
           platform_info['Ruby.Dalli.Version']      = "Dalli-#{::Dalli::VERSION}"           if defined?(::Dalli::VERSION)
           platform_info['Ruby.Excon.Version']      = "Excon-#{::Excon::VERSION}"           if defined?(::Excon::VERSION)
           platform_info['Ruby.Faraday.Version']    = "Faraday-#{::Faraday::VERSION}"       if defined?(::Faraday::VERSION)

--- a/test/instrumentation/curb_test.rb
+++ b/test/instrumentation/curb_test.rb
@@ -9,6 +9,7 @@ class CurbTest < Minitest::Test
   include Rack::Test::Methods
 
   def setup
+    clear_all_traces
     TraceView.config_lock.synchronize {
       @cb = TraceView::Config[:curb][:collect_backtraces]
       @log_args = TraceView::Config[:curb][:log_args]
@@ -37,8 +38,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_class_get_request
-    clear_all_traces
-
     response = nil
 
     TraceView::API.start_trace('curb_tests') do
@@ -66,8 +65,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_class_delete_request
-    clear_all_traces
-
     response = nil
 
     TraceView::API.start_trace('curb_tests') do
@@ -95,8 +92,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_class_post_request
-    clear_all_traces
-
     response = nil
 
     TraceView::API.start_trace('curb_tests') do
@@ -124,8 +119,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_easy_class_perform
-    clear_all_traces
-
     response = nil
 
     TraceView::API.start_trace('curb_tests') do
@@ -154,8 +147,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_easy_http_head
-    clear_all_traces
-
     c = nil
 
     TraceView::API.start_trace('curb_tests') do
@@ -184,8 +175,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_easy_http_put
-    clear_all_traces
-
     c = nil
 
     TraceView::API.start_trace('curb_tests') do
@@ -214,8 +203,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_easy_http_post
-    clear_all_traces
-
     c = nil
 
     TraceView::API.start_trace('curb_tests') do
@@ -245,8 +232,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_class_fetch_with_block
-    clear_all_traces
-
     response = nil
 
     TraceView::API.start_trace('curb_tests') do
@@ -277,7 +262,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_cross_app_tracing
-    clear_all_traces
     response = nil
 
     # When testing global config options, use the config_locak
@@ -314,8 +298,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_multi_basic
-    clear_all_traces
-
     responses = nil
     easy_options = {:follow_location => true}
     multi_options = {:pipeline => false}
@@ -342,8 +324,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_multi_basic_pipeline
-    clear_all_traces
-
     responses = nil
     easy_options = {:follow_location => true}
     multi_options = {:pipeline => true}
@@ -370,8 +350,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_requests_with_errors
-    clear_all_traces
-
     begin
       TraceView::API.start_trace('curb_tests') do
         Curl.get('http://asfjalkfjlajfljkaljf/')
@@ -400,8 +378,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_obey_log_args_when_false
-    clear_all_traces
-
     # When testing global config options, use the config_locak
     # semaphore to lock between other running tests.
     TraceView.config_lock.synchronize {
@@ -420,8 +396,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_obey_log_args_when_true
-    clear_all_traces
-
     # When testing global config options, use the config_locak
     # semaphore to lock between other running tests.
     TraceView.config_lock.synchronize {
@@ -440,7 +414,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_without_tracing_class_get
-    clear_all_traces
     TraceView::Config[:tracing_mode] = :never
 
     response = nil
@@ -458,7 +431,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_without_tracing_easy_perform
-    clear_all_traces
     response = nil
 
     # When testing global config options, use the config_locak
@@ -484,6 +456,7 @@ class CurbTest < Minitest::Test
     # semaphore to lock between other running tests.
     TraceView.config_lock.synchronize {
       TraceView::Config[:curb][:collect_backtraces] = true
+      sleep 1
 
       TraceView::API.start_trace('curb_test') do
         Curl.get("http://127.0.0.1:8101/")
@@ -495,7 +468,6 @@ class CurbTest < Minitest::Test
   end
 
   def test_obey_collect_backtraces_when_false
-    skip
     # When testing global config options, use the config_locak
     # semaphore to lock between other running tests.
     TraceView.config_lock.synchronize {

--- a/test/instrumentation/curb_test.rb
+++ b/test/instrumentation/curb_test.rb
@@ -1,0 +1,140 @@
+# Copyright (c) 2015 AppNeta, Inc.
+# All rights reserved.
+
+require 'minitest_helper'
+require 'traceview/inst/rack'
+require File.expand_path(File.dirname(__FILE__) + '../../frameworks/apps/sinatra_simple')
+
+class CurbTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    SinatraSimple
+  end
+
+  def test_must_return_xtrace_header
+    clear_all_traces
+    get "/"
+    xtrace = last_response['X-Trace']
+    assert xtrace
+    assert TraceView::XTrace.valid?(xtrace)
+  end
+
+  def test_reports_version_init
+    init_kvs = ::TraceView::Util.build_init_report
+    assert init_kvs.key?('Ruby.Curb.Version')
+    assert_equal init_kvs['Ruby.Curb.Version'], "Curb-#{::Curl::VERSION}"
+  end
+
+  def test_class_get_request
+    clear_all_traces
+
+    TraceView::API.start_trace('curb_tests') do
+      Curl.get('http://127.0.0.1:8101/')
+    end
+
+    traces = get_all_traces
+    assert_equal traces.count, 7
+    validate_outer_layers(traces, "curb_tests")
+    valid_edges?(traces)
+
+    assert_equal traces[1]['IsService'], 1
+    assert_equal traces[1]['RemoteURL'], "http://127.0.0.1:8101/"
+    # FIXME
+    # assert_equal traces[1]['HTTPMethod'], 'GET'
+    assert traces[1].key?('Backtrace')
+
+    assert_equal traces[5]['Layer'], 'curb'
+    assert_equal traces[5]['Label'], 'exit'
+    assert_equal traces[5]['HTTPStatus'], 200
+  end
+
+  def test_cross_app_tracing
+    clear_all_traces
+
+    TraceView::API.start_trace('curb_tests') do
+      response = ::Curl.get('http://127.0.0.1:8101/?blah=1')
+      xtrace = response.headers['X-Trace']
+      assert xtrace
+      assert TraceView::XTrace.valid?(xtrace)
+    end
+
+    traces = get_all_traces
+    assert_equal traces.count, 7
+    validate_outer_layers(traces, "curb_tests")
+    valid_edges?(traces)
+
+    assert_equal traces[1]['IsService'], 1
+    assert_equal traces[1]['RemoteURL'], "http://127.0.0.1:8101/?blah=1&"
+    # FIXME
+    # assert_equal traces[1]['HTTPMethod'], 'GET'
+    assert traces[1].key?('Backtrace')
+    assert_equal traces[5]['HTTPStatus'], 200
+  end
+
+  def test_requests_with_errors
+    clear_all_traces
+
+    begin
+      TraceView::API.start_trace('curb_tests') do
+        Curl.get('http://asfjalkfjlajfljkaljf/')
+      end
+    rescue
+    end
+
+    traces = get_all_traces
+    assert_equal traces.count, 5
+    validate_outer_layers(traces, "curb_tests")
+    valid_edges?(traces)
+
+    assert_equal traces[1]['IsService'], 1
+    assert_equal traces[1]['RemoteURL'], 'http://asfjalkfjlajfljkaljf/'
+    # FIXME
+    # assert_equal traces[1]['HTTPMethod'], 'GET'
+    assert traces[1].key?('Backtrace')
+
+    assert_equal traces[2]['Layer'], 'curb'
+    assert_equal traces[2]['Label'], 'error'
+    assert_equal traces[2]['ErrorClass'], "Curl::Err::HostResolutionError"
+    assert traces[2].key?('ErrorMsg')
+    assert traces[2].key?('Backtrace')
+
+    assert_equal traces[3]['Layer'], 'curb'
+    assert_equal traces[3]['Label'], 'exit'
+  end
+
+  def test_obey_log_args_when_false
+    @log_args = TraceView::Config[:curb][:log_args]
+    clear_all_traces
+
+    TraceView::Config[:curb][:log_args] = false
+
+    TraceView::API.start_trace('curb_tests') do
+      Curl.get('http://127.0.0.1:8101/?blah=1')
+    end
+
+    traces = get_all_traces
+    assert_equal traces.count, 7
+    assert_equal traces[1]['RemoteURL'], "http://127.0.0.1:8101/"
+
+    TraceView::Config[:curb][:log_args] = @log_args
+  end
+
+  def test_obey_log_args_when_true
+    @log_args = TraceView::Config[:curb][:log_args]
+    clear_all_traces
+
+    TraceView::Config[:curb][:log_args] = true
+
+    TraceView::API.start_trace('curb_tests') do
+      ::Curl.get('http://127.0.0.1:8101/?blah=1')
+    end
+
+    traces = get_all_traces
+    assert_equal traces.count, 7
+    assert_equal traces[1]['RemoteURL'], "http://127.0.0.1:8101/?blah=1&"
+
+    TraceView::Config[:curb][:log_args] = @log_args
+  end
+end
+

--- a/test/instrumentation/curb_test.rb
+++ b/test/instrumentation/curb_test.rb
@@ -1,544 +1,547 @@
 # Copyright (c) 2015 AppNeta, Inc.
 # All rights reserved.
 
-require 'minitest_helper'
-require 'traceview/inst/rack'
-require File.expand_path(File.dirname(__FILE__) + '../../frameworks/apps/sinatra_simple')
+if RUBY_VERSION > '1.8.7'
 
-class CurbTest < Minitest::Test
-  include Rack::Test::Methods
+  require 'minitest_helper'
+  require 'traceview/inst/rack'
+  require File.expand_path(File.dirname(__FILE__) + '../../frameworks/apps/sinatra_simple')
 
-  def setup
-    clear_all_traces
-    TraceView.config_lock.synchronize {
-      @cb = TraceView::Config[:curb][:collect_backtraces]
-      @log_args = TraceView::Config[:curb][:log_args]
-      @tm = TraceView::Config[:tracing_mode]
-      @cross_host = TraceView::Config[:curb][:cross_host]
-    }
-  end
+  class CurbTest < Minitest::Test
+    include Rack::Test::Methods
 
-  def teardown
-    TraceView.config_lock.synchronize {
-      TraceView::Config[:curb][:collect_backtraces] = @cb
-      TraceView::Config[:curb][:log_args] = @log_args
-      TraceView::Config[:tracing_mode] = @tm
-      TraceView::Config[:curb][:cross_host] = @cross_host
-    }
-  end
-
-  def app
-    SinatraSimple
-  end
-
-  def test_reports_version_init
-    init_kvs = ::TraceView::Util.build_init_report
-    assert init_kvs.key?('Ruby.Curb.Version')
-    assert_equal init_kvs['Ruby.Curb.Version'], "Curb-#{::Curl::VERSION}"
-  end
-
-  def test_class_get_request
-    response = nil
-
-    TraceView::API.start_trace('curb_tests') do
-      response = Curl.get('http://127.0.0.1:8101/')
+    def setup
+      clear_all_traces
+      TraceView.config_lock.synchronize {
+        @cb = TraceView::Config[:curb][:collect_backtraces]
+        @log_args = TraceView::Config[:curb][:log_args]
+        @tm = TraceView::Config[:tracing_mode]
+        @cross_host = TraceView::Config[:curb][:cross_host]
+      }
     end
 
-    assert response.body_str == "Hello TraceView!"
-    assert response.response_code == 200
-    assert response.header_str =~ /X-Trace/, "X-Trace response header"
-
-    traces = get_all_traces
-    assert_equal 7, traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-
-    assert_equal 'curb',                    traces[1]['Layer']
-    assert_equal 'entry',                   traces[1]['Label']
-    assert_equal 1,                         traces[1]['IsService']
-    assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
-    assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-    assert       traces[1].key?('Backtrace')
-
-    assert_equal 'curb',                    traces[5]['Layer']
-    assert_equal 'exit',                    traces[5]['Label']
-    assert_equal 200,                       traces[5]['HTTPStatus']
-  end
-
-  def test_class_delete_request
-    response = nil
-
-    TraceView::API.start_trace('curb_tests') do
-      response = Curl.delete('http://127.0.0.1:8101/?curb_delete_test', :id => 1)
+    def teardown
+      TraceView.config_lock.synchronize {
+        TraceView::Config[:curb][:collect_backtraces] = @cb
+        TraceView::Config[:curb][:log_args] = @log_args
+        TraceView::Config[:tracing_mode] = @tm
+        TraceView::Config[:curb][:cross_host] = @cross_host
+      }
     end
 
-    assert response.body_str == "Hello TraceView!"
-    assert response.response_code == 200
-    assert response.header_str =~ /X-Trace/, "X-Trace response header"
-
-    traces = get_all_traces
-    assert_equal 7, traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-
-    assert_equal 'curb',                    traces[1]['Layer']
-    assert_equal 'entry',                   traces[1]['Label']
-    assert_equal 1,                         traces[1]['IsService']
-    assert_equal 'DELETE',                  traces[1]['HTTPMethod'], "HTTP Method"
-    assert_equal "http://127.0.0.1:8101/?curb_delete_test",  traces[1]['RemoteURL']
-    assert       traces[1].key?('Backtrace')
-
-    assert_equal 'curb',                    traces[5]['Layer']
-    assert_equal 'exit',                    traces[5]['Label']
-    assert_equal 200,                       traces[5]['HTTPStatus']
-  end
-
-  def test_class_post_request
-    response = nil
-
-    TraceView::API.start_trace('curb_tests') do
-      response = Curl.post('http://127.0.0.1:8101/')
+    def app
+      SinatraSimple
     end
 
-    assert response.body_str == "Hello TraceView!"
-    assert response.response_code == 200
-    assert response.header_str =~ /X-Trace/, "X-Trace response header"
-
-    traces = get_all_traces
-    assert_equal 7, traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-
-    assert_equal 'curb',                    traces[1]['Layer']
-    assert_equal 'entry',                   traces[1]['Label']
-    assert_equal 1,                         traces[1]['IsService']
-    assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-    assert_equal 'POST',                    traces[1]['HTTPMethod'], "HTTP Method"
-    assert       traces[1].key?('Backtrace')
-
-    assert_equal 'curb',                    traces[5]['Layer']
-    assert_equal 'exit',                    traces[5]['Label']
-    assert_equal 200,                       traces[5]['HTTPStatus']
-  end
-
-  def test_easy_class_perform
-    response = nil
-
-    TraceView::API.start_trace('curb_tests') do
-      response = Curl::Easy.perform("http://127.0.0.1:8101/")
+    def test_reports_version_init
+      init_kvs = ::TraceView::Util.build_init_report
+      assert init_kvs.key?('Ruby.Curb.Version')
+      assert_equal init_kvs['Ruby.Curb.Version'], "Curb-#{::Curl::VERSION}"
     end
 
-    assert response.is_a?(::Curl::Easy)
-    assert response.body_str == "Hello TraceView!"
-    assert response.response_code == 200
-    assert response.header_str =~ /X-Trace/, "X-Trace response header"
-
-    traces = get_all_traces
-    assert_equal 7,                         traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-
-    assert_equal 'curb',                    traces[1]['Layer']
-    assert_equal 'entry',                   traces[1]['Label']
-    assert_equal 1,                         traces[1]['IsService']
-    assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-    assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
-    assert       traces[1].key?('Backtrace')
-
-    assert_equal 'curb',                    traces[5]['Layer']
-    assert_equal 'exit',                    traces[5]['Label']
-    assert_equal 200,                       traces[5]['HTTPStatus']
-  end
-
-  def test_easy_http_head
-    c = nil
-
-    TraceView::API.start_trace('curb_tests') do
-      c = Curl::Easy.new("http://127.0.0.1:8101/")
-      c.http_head
-    end
-
-    assert c.is_a?(::Curl::Easy), "Response type"
-    assert c.response_code == 200
-    assert c.header_str =~ /X-Trace/, "X-Trace response header"
-
-    traces = get_all_traces
-    assert_equal 7, traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-
-    assert_equal 'curb',                    traces[1]['Layer']
-    assert_equal 'entry',                   traces[1]['Label']
-    assert_equal 1,                         traces[1]['IsService']
-    assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-    assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
-    assert       traces[1].key?('Backtrace')
-
-    assert_equal 'curb',                    traces[5]['Layer']
-    assert_equal 'exit',                    traces[5]['Label']
-    assert_equal 200,                       traces[5]['HTTPStatus']
-  end
-
-  def test_easy_http_put
-    c = nil
-
-    TraceView::API.start_trace('curb_tests') do
-      c = Curl::Easy.new("http://127.0.0.1:8101/")
-      c.http_put(:id => 1)
-    end
-
-    assert c.is_a?(::Curl::Easy), "Response type"
-    assert c.response_code == 200
-    assert c.header_str =~ /X-Trace/, "X-Trace response header"
-
-    traces = get_all_traces
-    assert_equal 7, traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-
-    assert_equal 'curb',                    traces[1]['Layer']
-    assert_equal 'entry',                   traces[1]['Label']
-    assert_equal 1,                         traces[1]['IsService']
-    assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-    assert_equal 'PUT',                     traces[1]['HTTPMethod'], "HTTP Method"
-    assert       traces[1].key?('Backtrace')
-
-    assert_equal 'curb',                    traces[5]['Layer']
-    assert_equal 'exit',                    traces[5]['Label']
-    assert_equal 200,                       traces[5]['HTTPStatus']
-  end
-
-  def test_easy_http_post
-    c = nil
-
-    TraceView::API.start_trace('curb_tests') do
-      url = "http://127.0.0.1:8101/"
-      c = Curl::Easy.new(url)
-      c.http_post(url, :id => 1)
-    end
-
-    assert c.is_a?(::Curl::Easy), "Response type"
-    assert c.response_code == 200
-    assert c.header_str =~ /X-Trace/, "X-Trace response header"
-
-    traces = get_all_traces
-    assert_equal 7, traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-
-    assert_equal 'curb',                    traces[1]['Layer']
-    assert_equal 'entry',                   traces[1]['Label']
-    assert_equal 1,                         traces[1]['IsService']
-    assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-    assert_equal 'POST',                    traces[1]['HTTPMethod'], "HTTP Method"
-    assert       traces[1].key?('Backtrace')
-
-    assert_equal 'curb',                    traces[5]['Layer']
-    assert_equal 'exit',                    traces[5]['Label']
-    assert_equal 200,                       traces[5]['HTTPStatus']
-  end
-
-  def test_class_fetch_with_block
-    response = nil
-
-    TraceView::API.start_trace('curb_tests') do
-      response = Curl::Easy.perform("http://127.0.0.1:8101/") do |curl|
-        curl.headers["User-Agent"] = "TraceView 2000"
-      end
-    end
-
-    assert response.is_a?(::Curl::Easy), "Response type"
-    assert response.response_code == 200
-    assert response.header_str =~ /X-Trace/, "X-Trace response header"
-
-    traces = get_all_traces
-    assert_equal 7, traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-
-    assert_equal 'curb',                    traces[1]['Layer']
-    assert_equal 'entry',                   traces[1]['Label']
-    assert_equal traces[5]['Label'], 'exit'
-    assert_equal 1,                         traces[1]['IsService']
-    assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-    assert_equal 'GET',                     traces[1]['HTTPMethod']
-    assert traces[1].key?('Backtrace')
-
-    assert_equal 'curb',                    traces[5]['Layer']
-    assert_equal 'exit',                    traces[5]['Label']
-    assert_equal 200,                       traces[5]['HTTPStatus']
-  end
-
-  def test_cross_app_tracing
-    response = nil
-
-    # When testing global config options, use the config_locak
-    # semaphore to lock between other running tests.
-    TraceView.config_lock.synchronize {
-      TraceView::Config[:curb][:cross_host] = true
+    def test_class_get_request
+      response = nil
 
       TraceView::API.start_trace('curb_tests') do
-        response = ::Curl.get('http://127.0.0.1:8101/?curb_cross_host=1')
+        response = Curl.get('http://127.0.0.1:8101/')
       end
-    }
 
-    xtrace = response.headers['X-Trace']
-    assert xtrace, "X-Trace response header"
-    assert TraceView::XTrace.valid?(xtrace)
-    assert response.header_str =~ /X-Trace/, "X-Trace response header"
+      assert response.body_str == "Hello TraceView!"
+      assert response.response_code == 200
+      assert response.header_str =~ /X-Trace/, "X-Trace response header"
 
-    traces = get_all_traces
-    assert_equal 7, traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-    assert valid_edges?(traces), "Trace edge validation"
+      traces = get_all_traces
+      assert_equal 7, traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
 
-    assert_equal 'curb',                    traces[1]['Layer']
-    assert_equal 'entry',                   traces[1]['Label']
-    assert_equal 1,                         traces[1]['IsService']
-    assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
-    assert_equal "http://127.0.0.1:8101/?curb_cross_host=1&",  traces[1]['RemoteURL']
-    assert       traces[1].key?('Backtrace')
+      assert_equal 'curb',                    traces[1]['Layer']
+      assert_equal 'entry',                   traces[1]['Label']
+      assert_equal 1,                         traces[1]['IsService']
+      assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
+      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
+      assert       traces[1].key?('Backtrace')
 
-    assert_equal 'curb',                    traces[5]['Layer']
-    assert_equal 'exit',                    traces[5]['Label']
-    assert_equal 200,                       traces[5]['HTTPStatus']
-
-  end
-
-  def test_multi_basic_get
-    responses = nil
-    easy_options = {:follow_location => true}
-    multi_options = {:pipeline => false}
-
-    urls = []
-    urls << "http://127.0.0.1:8101/?one=1"
-    urls << "http://127.0.0.1:8101/?two=2"
-    urls << "http://127.0.0.1:8101/?three=3"
-
-    TraceView::API.start_trace('curb_tests') do
-      responses = Curl::Multi.get(urls, easy_options, multi_options) do |easy|
-        nil
-      end
+      assert_equal 'curb',                    traces[5]['Layer']
+      assert_equal 'exit',                    traces[5]['Label']
+      assert_equal 200,                       traces[5]['HTTPStatus']
     end
 
-    traces = get_all_traces
-    assert_equal 13, traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-
-    assert_equal traces[1]['Layer'], 'curb_multi'
-    assert_equal traces[1]['Label'], 'entry'
-    assert_equal traces[11]['Layer'], 'curb_multi'
-    assert_equal traces[11]['Label'], 'exit'
-  end
-
-  def test_multi_basic_post
-    responses = nil
-    easy_options = {:follow_location => true, :multipart_form_post => true}
-    multi_options = {:pipeline => true}
-
-    urls = []
-    urls << { :url => "http://127.0.0.1:8101/1", :post_fields => { :id => 1 } }
-    urls << { :url => "http://127.0.0.1:8101/2", :post_fields => { :id => 2 } }
-    urls << { :url => "http://127.0.0.1:8101/3", :post_fields => { :id => 3 } }
-
-    TraceView::API.start_trace('curb_tests') do
-      responses = Curl::Multi.post(urls, easy_options, multi_options) do |easy|
-        nil
-      end
-    end
-
-    traces = get_all_traces
-    assert_equal 13, traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-
-    assert_equal traces[1]['Layer'], 'curb_multi'
-    assert_equal traces[1]['Label'], 'entry'
-    assert_equal traces[11]['Layer'], 'curb_multi'
-    assert_equal traces[11]['Label'], 'exit'
-  end
-
-  def test_multi_basic_get_pipeline
-    responses = nil
-    easy_options = {:follow_location => true}
-    multi_options = {:pipeline => true}
-
-    urls = []
-    urls << "http://127.0.0.1:8101/?one=1"
-    urls << "http://127.0.0.1:8101/?two=2"
-    urls << "http://127.0.0.1:8101/?three=3"
-
-    TraceView::API.start_trace('curb_tests') do
-      responses = Curl::Multi.get(urls, easy_options, multi_options) do |easy|
-        nil
-      end
-    end
-
-    traces = get_all_traces
-    assert_equal 13, traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-
-    assert_equal traces[1]['Layer'], 'curb_multi'
-    assert_equal traces[1]['Label'], 'entry'
-    assert_equal traces[11]['Layer'], 'curb_multi'
-    assert_equal traces[11]['Label'], 'exit'
-  end
-
-  def test_multi_advanced_get
-    responses = {}
-
-    urls = []
-    urls << "http://127.0.0.1:8101/?one=1"
-    urls << "http://127.0.0.1:8101/?two=2"
-    urls << "http://127.0.0.1:8101/?three=3"
-
-    TraceView::API.start_trace('curb_tests') do
-      m = Curl::Multi.new
-      urls.each do |url|
-        responses[url] = ""
-        c = Curl::Easy.new(url) do |curl|
-          curl.follow_location = true
-        end
-        m.add c
-      end
-
-      m.perform do
-        nil
-      end
-    end
-
-    traces = get_all_traces
-    assert_equal 13, traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-
-    assert_equal traces[1]['Layer'], 'curb_multi'
-    assert_equal traces[1]['Label'], 'entry'
-    assert_equal traces[11]['Layer'], 'curb_multi'
-    assert_equal traces[11]['Label'], 'exit'
-  end
-
-  def test_requests_with_errors
-    begin
-      TraceView::API.start_trace('curb_tests') do
-        Curl.get('http://asfjalkfjlajfljkaljf/')
-      end
-    rescue
-    end
-
-    traces = get_all_traces
-    assert_equal 5, traces.count, "Trace count"
-    validate_outer_layers(traces, "curb_tests")
-    assert valid_edges?(traces), "Trace edge validation"
-
-    assert_equal 1,                                traces[1]['IsService']
-    assert_equal 'http://asfjalkfjlajfljkaljf/',   traces[1]['RemoteURL']
-    assert_equal 'GET',                            traces[1]['HTTPMethod']
-    assert traces[1].key?('Backtrace')
-
-    assert_equal 'curb',                           traces[2]['Layer']
-    assert_equal 'error',                          traces[2]['Label']
-    assert_equal "Curl::Err::HostResolutionError", traces[2]['ErrorClass']
-    assert traces[2].key?('ErrorMsg')
-    assert traces[2].key?('Backtrace')
-
-    assert_equal 'curb',                           traces[3]['Layer']
-    assert_equal 'exit',                           traces[3]['Label']
-  end
-
-  def test_obey_log_args_when_false
-    # When testing global config options, use the config_locak
-    # semaphore to lock between other running tests.
-    TraceView.config_lock.synchronize {
-      TraceView::Config[:curb][:log_args] = false
-
-      http = nil
+    def test_class_delete_request
+      response = nil
 
       TraceView::API.start_trace('curb_tests') do
-        http = Curl.get('http://127.0.0.1:8101/?blah=1')
+        response = Curl.delete('http://127.0.0.1:8101/?curb_delete_test', :id => 1)
       end
-    }
 
-    traces = get_all_traces
-    assert_equal 7, traces.count, "Trace count"
-    assert_equal "http://127.0.0.1:8101/",         traces[1]['RemoteURL']
-  end
+      assert response.body_str == "Hello TraceView!"
+      assert response.response_code == 200
+      assert response.header_str =~ /X-Trace/, "X-Trace response header"
 
-  def test_obey_log_args_when_true
-    # When testing global config options, use the config_locak
-    # semaphore to lock between other running tests.
-    TraceView.config_lock.synchronize {
-      TraceView::Config[:curb][:log_args] = true
+      traces = get_all_traces
+      assert_equal 7, traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
 
-      http = nil
+      assert_equal 'curb',                    traces[1]['Layer']
+      assert_equal 'entry',                   traces[1]['Label']
+      assert_equal 1,                         traces[1]['IsService']
+      assert_equal 'DELETE',                  traces[1]['HTTPMethod'], "HTTP Method"
+      assert_equal "http://127.0.0.1:8101/?curb_delete_test",  traces[1]['RemoteURL']
+      assert       traces[1].key?('Backtrace')
 
-      TraceView::API.start_trace('curb_tests') do
-        http = ::Curl.get('http://127.0.0.1:8101/?blah=1')
-      end
-    }
-
-    traces = get_all_traces
-    assert_equal 7, traces.count, "Trace count"
-    assert_equal "http://127.0.0.1:8101/?blah=1&", traces[1]['RemoteURL']
-  end
-
-  def test_without_tracing_class_get
-    TraceView::Config[:tracing_mode] = :never
-
-    response = nil
-
-    TraceView::API.start_trace('httpclient_tests') do
-      response = ::Curl.get('http://127.0.0.1:8101/?blah=1')
+      assert_equal 'curb',                    traces[5]['Layer']
+      assert_equal 'exit',                    traces[5]['Label']
+      assert_equal 200,                       traces[5]['HTTPStatus']
     end
 
-    assert response.headers['X-Trace'] == nil
-    assert response.body_str == "Hello TraceView!"
-    assert response.response_code == 200
+    def test_class_post_request
+      response = nil
 
-    traces = get_all_traces
-    assert_equal 0, traces.count, "Trace count"
-  end
+      TraceView::API.start_trace('curb_tests') do
+        response = Curl.post('http://127.0.0.1:8101/')
+      end
 
-  def test_without_tracing_easy_perform
-    response = nil
+      assert response.body_str == "Hello TraceView!"
+      assert response.response_code == 200
+      assert response.header_str =~ /X-Trace/, "X-Trace response header"
 
-    # When testing global config options, use the config_locak
-    # semaphore to lock between other running tests.
-    TraceView.config_lock.synchronize {
-      TraceView::Config[:tracing_mode] = :never
+      traces = get_all_traces
+      assert_equal 7, traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
+
+      assert_equal 'curb',                    traces[1]['Layer']
+      assert_equal 'entry',                   traces[1]['Label']
+      assert_equal 1,                         traces[1]['IsService']
+      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
+      assert_equal 'POST',                    traces[1]['HTTPMethod'], "HTTP Method"
+      assert       traces[1].key?('Backtrace')
+
+      assert_equal 'curb',                    traces[5]['Layer']
+      assert_equal 'exit',                    traces[5]['Label']
+      assert_equal 200,                       traces[5]['HTTPStatus']
+    end
+
+    def test_easy_class_perform
+      response = nil
 
       TraceView::API.start_trace('curb_tests') do
         response = Curl::Easy.perform("http://127.0.0.1:8101/")
       end
-    }
 
-    assert response.headers['X-Trace'] == nil
-    assert response.body_str == "Hello TraceView!"
-    assert response.response_code == 200
+      assert response.is_a?(::Curl::Easy)
+      assert response.body_str == "Hello TraceView!"
+      assert response.response_code == 200
+      assert response.header_str =~ /X-Trace/, "X-Trace response header"
 
-    traces = get_all_traces
-    assert_equal 0, traces.count, "Trace count"
-  end
+      traces = get_all_traces
+      assert_equal 7,                         traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
 
-  def test_obey_collect_backtraces_when_true
-    # When testing global config options, use the config_locak
-    # semaphore to lock between other running tests.
-    TraceView.config_lock.synchronize {
-      TraceView::Config[:curb][:collect_backtraces] = true
-      sleep 1
+      assert_equal 'curb',                    traces[1]['Layer']
+      assert_equal 'entry',                   traces[1]['Label']
+      assert_equal 1,                         traces[1]['IsService']
+      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
+      assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
+      assert       traces[1].key?('Backtrace')
 
-      TraceView::API.start_trace('curb_test') do
-        Curl.get("http://127.0.0.1:8101/")
+      assert_equal 'curb',                    traces[5]['Layer']
+      assert_equal 'exit',                    traces[5]['Label']
+      assert_equal 200,                       traces[5]['HTTPStatus']
+    end
+
+    def test_easy_http_head
+      c = nil
+
+      TraceView::API.start_trace('curb_tests') do
+        c = Curl::Easy.new("http://127.0.0.1:8101/")
+        c.http_head
       end
-    }
 
-    traces = get_all_traces
-    layer_has_key(traces, 'curb', 'Backtrace')
-  end
+      assert c.is_a?(::Curl::Easy), "Response type"
+      assert c.response_code == 200
+      assert c.header_str =~ /X-Trace/, "X-Trace response header"
 
-  def test_obey_collect_backtraces_when_false
-    # When testing global config options, use the config_locak
-    # semaphore to lock between other running tests.
-    TraceView.config_lock.synchronize {
-      TraceView::Config[:curb][:collect_backtraces] = false
+      traces = get_all_traces
+      assert_equal 7, traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
 
-      TraceView::API.start_trace('curb_test') do
-        Curl.get("http://127.0.0.1:8101/")
+      assert_equal 'curb',                    traces[1]['Layer']
+      assert_equal 'entry',                   traces[1]['Label']
+      assert_equal 1,                         traces[1]['IsService']
+      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
+      assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
+      assert       traces[1].key?('Backtrace')
+
+      assert_equal 'curb',                    traces[5]['Layer']
+      assert_equal 'exit',                    traces[5]['Label']
+      assert_equal 200,                       traces[5]['HTTPStatus']
+    end
+
+    def test_easy_http_put
+      c = nil
+
+      TraceView::API.start_trace('curb_tests') do
+        c = Curl::Easy.new("http://127.0.0.1:8101/")
+        c.http_put(:id => 1)
       end
-    }
 
-    traces = get_all_traces
-    layer_doesnt_have_key(traces, 'curb', 'Backtrace')
+      assert c.is_a?(::Curl::Easy), "Response type"
+      assert c.response_code == 200
+      assert c.header_str =~ /X-Trace/, "X-Trace response header"
+
+      traces = get_all_traces
+      assert_equal 7, traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
+
+      assert_equal 'curb',                    traces[1]['Layer']
+      assert_equal 'entry',                   traces[1]['Label']
+      assert_equal 1,                         traces[1]['IsService']
+      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
+      assert_equal 'PUT',                     traces[1]['HTTPMethod'], "HTTP Method"
+      assert       traces[1].key?('Backtrace')
+
+      assert_equal 'curb',                    traces[5]['Layer']
+      assert_equal 'exit',                    traces[5]['Label']
+      assert_equal 200,                       traces[5]['HTTPStatus']
+    end
+
+    def test_easy_http_post
+      c = nil
+
+      TraceView::API.start_trace('curb_tests') do
+        url = "http://127.0.0.1:8101/"
+        c = Curl::Easy.new(url)
+        c.http_post(url, :id => 1)
+      end
+
+      assert c.is_a?(::Curl::Easy), "Response type"
+      assert c.response_code == 200
+      assert c.header_str =~ /X-Trace/, "X-Trace response header"
+
+      traces = get_all_traces
+      assert_equal 7, traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
+
+      assert_equal 'curb',                    traces[1]['Layer']
+      assert_equal 'entry',                   traces[1]['Label']
+      assert_equal 1,                         traces[1]['IsService']
+      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
+      assert_equal 'POST',                    traces[1]['HTTPMethod'], "HTTP Method"
+      assert       traces[1].key?('Backtrace')
+
+      assert_equal 'curb',                    traces[5]['Layer']
+      assert_equal 'exit',                    traces[5]['Label']
+      assert_equal 200,                       traces[5]['HTTPStatus']
+    end
+
+    def test_class_fetch_with_block
+      response = nil
+
+      TraceView::API.start_trace('curb_tests') do
+        response = Curl::Easy.perform("http://127.0.0.1:8101/") do |curl|
+          curl.headers["User-Agent"] = "TraceView 2000"
+        end
+      end
+
+      assert response.is_a?(::Curl::Easy), "Response type"
+      assert response.response_code == 200
+      assert response.header_str =~ /X-Trace/, "X-Trace response header"
+
+      traces = get_all_traces
+      assert_equal 7, traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
+
+      assert_equal 'curb',                    traces[1]['Layer']
+      assert_equal 'entry',                   traces[1]['Label']
+      assert_equal traces[5]['Label'], 'exit'
+      assert_equal 1,                         traces[1]['IsService']
+      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
+      assert_equal 'GET',                     traces[1]['HTTPMethod']
+      assert traces[1].key?('Backtrace')
+
+      assert_equal 'curb',                    traces[5]['Layer']
+      assert_equal 'exit',                    traces[5]['Label']
+      assert_equal 200,                       traces[5]['HTTPStatus']
+    end
+
+    def test_cross_app_tracing
+      response = nil
+
+      # When testing global config options, use the config_locak
+      # semaphore to lock between other running tests.
+      TraceView.config_lock.synchronize {
+        TraceView::Config[:curb][:cross_host] = true
+
+        TraceView::API.start_trace('curb_tests') do
+          response = ::Curl.get('http://127.0.0.1:8101/?curb_cross_host=1')
+        end
+      }
+
+      xtrace = response.headers['X-Trace']
+      assert xtrace, "X-Trace response header"
+      assert TraceView::XTrace.valid?(xtrace)
+      assert response.header_str =~ /X-Trace/, "X-Trace response header"
+
+      traces = get_all_traces
+      assert_equal 7, traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
+      assert valid_edges?(traces), "Trace edge validation"
+
+      assert_equal 'curb',                    traces[1]['Layer']
+      assert_equal 'entry',                   traces[1]['Label']
+      assert_equal 1,                         traces[1]['IsService']
+      assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
+      assert_equal "http://127.0.0.1:8101/?curb_cross_host=1&",  traces[1]['RemoteURL']
+      assert       traces[1].key?('Backtrace')
+
+      assert_equal 'curb',                    traces[5]['Layer']
+      assert_equal 'exit',                    traces[5]['Label']
+      assert_equal 200,                       traces[5]['HTTPStatus']
+
+    end
+
+    def test_multi_basic_get
+      responses = nil
+      easy_options = {:follow_location => true}
+      multi_options = {:pipeline => false}
+
+      urls = []
+      urls << "http://127.0.0.1:8101/?one=1"
+      urls << "http://127.0.0.1:8101/?two=2"
+      urls << "http://127.0.0.1:8101/?three=3"
+
+      TraceView::API.start_trace('curb_tests') do
+        responses = Curl::Multi.get(urls, easy_options, multi_options) do |easy|
+          nil
+        end
+      end
+
+      traces = get_all_traces
+      assert_equal 13, traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
+
+      assert_equal traces[1]['Layer'], 'curb_multi'
+      assert_equal traces[1]['Label'], 'entry'
+      assert_equal traces[11]['Layer'], 'curb_multi'
+      assert_equal traces[11]['Label'], 'exit'
+    end
+
+    def test_multi_basic_post
+      responses = nil
+      easy_options = {:follow_location => true, :multipart_form_post => true}
+      multi_options = {:pipeline => true}
+
+      urls = []
+      urls << { :url => "http://127.0.0.1:8101/1", :post_fields => { :id => 1 } }
+      urls << { :url => "http://127.0.0.1:8101/2", :post_fields => { :id => 2 } }
+      urls << { :url => "http://127.0.0.1:8101/3", :post_fields => { :id => 3 } }
+
+      TraceView::API.start_trace('curb_tests') do
+        responses = Curl::Multi.post(urls, easy_options, multi_options) do |easy|
+          nil
+        end
+      end
+
+      traces = get_all_traces
+      assert_equal 13, traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
+
+      assert_equal traces[1]['Layer'], 'curb_multi'
+      assert_equal traces[1]['Label'], 'entry'
+      assert_equal traces[11]['Layer'], 'curb_multi'
+      assert_equal traces[11]['Label'], 'exit'
+    end
+
+    def test_multi_basic_get_pipeline
+      responses = nil
+      easy_options = {:follow_location => true}
+      multi_options = {:pipeline => true}
+
+      urls = []
+      urls << "http://127.0.0.1:8101/?one=1"
+      urls << "http://127.0.0.1:8101/?two=2"
+      urls << "http://127.0.0.1:8101/?three=3"
+
+      TraceView::API.start_trace('curb_tests') do
+        responses = Curl::Multi.get(urls, easy_options, multi_options) do |easy|
+          nil
+        end
+      end
+
+      traces = get_all_traces
+      assert_equal 13, traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
+
+      assert_equal traces[1]['Layer'], 'curb_multi'
+      assert_equal traces[1]['Label'], 'entry'
+      assert_equal traces[11]['Layer'], 'curb_multi'
+      assert_equal traces[11]['Label'], 'exit'
+    end
+
+    def test_multi_advanced_get
+      responses = {}
+
+      urls = []
+      urls << "http://127.0.0.1:8101/?one=1"
+      urls << "http://127.0.0.1:8101/?two=2"
+      urls << "http://127.0.0.1:8101/?three=3"
+
+      TraceView::API.start_trace('curb_tests') do
+        m = Curl::Multi.new
+        urls.each do |url|
+          responses[url] = ""
+          c = Curl::Easy.new(url) do |curl|
+            curl.follow_location = true
+          end
+          m.add c
+        end
+
+        m.perform do
+          nil
+        end
+      end
+
+      traces = get_all_traces
+      assert_equal 13, traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
+
+      assert_equal traces[1]['Layer'], 'curb_multi'
+      assert_equal traces[1]['Label'], 'entry'
+      assert_equal traces[11]['Layer'], 'curb_multi'
+      assert_equal traces[11]['Label'], 'exit'
+    end
+
+    def test_requests_with_errors
+      begin
+        TraceView::API.start_trace('curb_tests') do
+          Curl.get('http://asfjalkfjlajfljkaljf/')
+        end
+      rescue
+      end
+
+      traces = get_all_traces
+      assert_equal 5, traces.count, "Trace count"
+      validate_outer_layers(traces, "curb_tests")
+      assert valid_edges?(traces), "Trace edge validation"
+
+      assert_equal 1,                                traces[1]['IsService']
+      assert_equal 'http://asfjalkfjlajfljkaljf/',   traces[1]['RemoteURL']
+      assert_equal 'GET',                            traces[1]['HTTPMethod']
+      assert traces[1].key?('Backtrace')
+
+      assert_equal 'curb',                           traces[2]['Layer']
+      assert_equal 'error',                          traces[2]['Label']
+      assert_equal "Curl::Err::HostResolutionError", traces[2]['ErrorClass']
+      assert traces[2].key?('ErrorMsg')
+      assert traces[2].key?('Backtrace')
+
+      assert_equal 'curb',                           traces[3]['Layer']
+      assert_equal 'exit',                           traces[3]['Label']
+    end
+
+    def test_obey_log_args_when_false
+      # When testing global config options, use the config_locak
+      # semaphore to lock between other running tests.
+      TraceView.config_lock.synchronize {
+        TraceView::Config[:curb][:log_args] = false
+
+        http = nil
+
+        TraceView::API.start_trace('curb_tests') do
+          http = Curl.get('http://127.0.0.1:8101/?blah=1')
+        end
+      }
+
+      traces = get_all_traces
+      assert_equal 7, traces.count, "Trace count"
+      assert_equal "http://127.0.0.1:8101/",         traces[1]['RemoteURL']
+    end
+
+    def test_obey_log_args_when_true
+      # When testing global config options, use the config_locak
+      # semaphore to lock between other running tests.
+      TraceView.config_lock.synchronize {
+        TraceView::Config[:curb][:log_args] = true
+
+        http = nil
+
+        TraceView::API.start_trace('curb_tests') do
+          http = ::Curl.get('http://127.0.0.1:8101/?blah=1')
+        end
+      }
+
+      traces = get_all_traces
+      assert_equal 7, traces.count, "Trace count"
+      assert_equal "http://127.0.0.1:8101/?blah=1&", traces[1]['RemoteURL']
+    end
+
+    def test_without_tracing_class_get
+      TraceView::Config[:tracing_mode] = :never
+
+      response = nil
+
+      TraceView::API.start_trace('httpclient_tests') do
+        response = ::Curl.get('http://127.0.0.1:8101/?blah=1')
+      end
+
+      assert response.headers['X-Trace'] == nil
+      assert response.body_str == "Hello TraceView!"
+      assert response.response_code == 200
+
+      traces = get_all_traces
+      assert_equal 0, traces.count, "Trace count"
+    end
+
+    def test_without_tracing_easy_perform
+      response = nil
+
+      # When testing global config options, use the config_locak
+      # semaphore to lock between other running tests.
+      TraceView.config_lock.synchronize {
+        TraceView::Config[:tracing_mode] = :never
+
+        TraceView::API.start_trace('curb_tests') do
+          response = Curl::Easy.perform("http://127.0.0.1:8101/")
+        end
+      }
+
+      assert response.headers['X-Trace'] == nil
+      assert response.body_str == "Hello TraceView!"
+      assert response.response_code == 200
+
+      traces = get_all_traces
+      assert_equal 0, traces.count, "Trace count"
+    end
+
+    def test_obey_collect_backtraces_when_true
+      # When testing global config options, use the config_locak
+      # semaphore to lock between other running tests.
+      TraceView.config_lock.synchronize {
+        TraceView::Config[:curb][:collect_backtraces] = true
+        sleep 1
+
+        TraceView::API.start_trace('curb_test') do
+          Curl.get("http://127.0.0.1:8101/")
+        end
+      }
+
+      traces = get_all_traces
+      layer_has_key(traces, 'curb', 'Backtrace')
+    end
+
+    def test_obey_collect_backtraces_when_false
+      # When testing global config options, use the config_locak
+      # semaphore to lock between other running tests.
+      TraceView.config_lock.synchronize {
+        TraceView::Config[:curb][:collect_backtraces] = false
+
+        TraceView::API.start_trace('curb_test') do
+          Curl.get("http://127.0.0.1:8101/")
+        end
+      }
+
+      traces = get_all_traces
+      layer_doesnt_have_key(traces, 'curb', 'Backtrace')
+    end
   end
 end
 

--- a/test/instrumentation/curb_test.rb
+++ b/test/instrumentation/curb_test.rb
@@ -21,54 +21,91 @@ class CurbTest < Minitest::Test
   def test_class_get_request
     clear_all_traces
 
-    http = nil
+    response = nil
 
     TraceView::API.start_trace('curb_tests') do
-      http = Curl.get('http://127.0.0.1:8101/')
+      response = Curl.get('http://127.0.0.1:8101/')
     end
 
+    assert response.body_str == "Hello TraceView!"
+    assert response.response_code == 200
+    assert response.header_str =~ /X-Trace/, "X-Trace response header"
+
     traces = get_all_traces
-    assert_equal traces.count, 7
+    assert_equal 7, traces.count, "Trace count"
     validate_outer_layers(traces, "curb_tests")
-    valid_edges?(traces)
 
-    assert_equal traces[1]['IsService'], 1
-    assert_equal traces[1]['RemoteURL'], "http://127.0.0.1:8101/"
-    # FIXME
-    # assert_equal traces[1]['HTTPMethod'], 'GET'
-    assert traces[1].key?('Backtrace')
+    assert_equal 'curb',                    traces[1]['Layer']
+    assert_equal 'entry',                   traces[1]['Label']
+    assert_equal 1,                         traces[1]['IsService']
+    assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
+    assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
+    assert       traces[1].key?('Backtrace')
 
-    assert_equal traces[5]['Layer'], 'curb'
-    assert_equal traces[5]['Label'], 'exit'
-    assert_equal traces[5]['HTTPStatus'], 200
+    assert_equal 'curb',                    traces[5]['Layer']
+    assert_equal 'exit',                    traces[5]['Label']
+    assert_equal 200,                       traces[5]['HTTPStatus']
+  end
+
+  def test_class_delete_request
+    clear_all_traces
+
+    response = nil
+
+    TraceView::API.start_trace('curb_tests') do
+      response = Curl.delete('http://127.0.0.1:8101/?curb_delete_test', :id => 1)
+    end
+
+    assert response.body_str == "Hello TraceView!"
+    assert response.response_code == 200
+    assert response.header_str =~ /X-Trace/, "X-Trace response header"
+
+    traces = get_all_traces
+    assert_equal 7, traces.count, "Trace count"
+    validate_outer_layers(traces, "curb_tests")
+
+    assert_equal 'curb',                    traces[1]['Layer']
+    assert_equal 'entry',                   traces[1]['Label']
+    assert_equal 1,                         traces[1]['IsService']
+    assert_equal 'DELETE',                  traces[1]['HTTPMethod'], "HTTP Method"
+    assert_equal "http://127.0.0.1:8101/?curb_delete_test",  traces[1]['RemoteURL']
+    assert       traces[1].key?('Backtrace')
+
+    assert_equal 'curb',                    traces[5]['Layer']
+    assert_equal 'exit',                    traces[5]['Label']
+    assert_equal 200,                       traces[5]['HTTPStatus']
   end
 
   def test_class_post_request
     clear_all_traces
 
-    http = nil
+    response = nil
 
     TraceView::API.start_trace('curb_tests') do
-      http = Curl.post('http://127.0.0.1:8101/')
+      response = Curl.post('http://127.0.0.1:8101/')
     end
 
+    assert response.body_str == "Hello TraceView!"
+    assert response.response_code == 200
+    assert response.header_str =~ /X-Trace/, "X-Trace response header"
+
     traces = get_all_traces
-    assert_equal traces.count, 7
+    assert_equal 7, traces.count, "Trace count"
     validate_outer_layers(traces, "curb_tests")
-    valid_edges?(traces)
 
-    assert_equal traces[1]['IsService'], 1
-    assert_equal traces[1]['RemoteURL'], "http://127.0.0.1:8101/"
-    # FIXME
-    # assert_equal traces[1]['HTTPMethod'], 'POST'
-    assert traces[1].key?('Backtrace')
+    assert_equal 'curb',                    traces[1]['Layer']
+    assert_equal 'entry',                   traces[1]['Label']
+    assert_equal 1,                         traces[1]['IsService']
+    assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
+    assert_equal 'POST',                    traces[1]['HTTPMethod'], "HTTP Method"
+    assert       traces[1].key?('Backtrace')
 
-    assert_equal traces[5]['Layer'], 'curb'
-    assert_equal traces[5]['Label'], 'exit'
-    assert_equal traces[5]['HTTPStatus'], 200
+    assert_equal 'curb',                    traces[5]['Layer']
+    assert_equal 'exit',                    traces[5]['Label']
+    assert_equal 200,                       traces[5]['HTTPStatus']
   end
 
-  def test_class_fetch
+  def test_easy_class_perform
     clear_all_traces
 
     response = nil
@@ -77,24 +114,55 @@ class CurbTest < Minitest::Test
       response = Curl::Easy.perform("http://127.0.0.1:8101/")
     end
 
-    xtrace = response.headers['X-Trace']
-    assert xtrace
-    assert TraceView::XTrace.valid?(xtrace)
+    assert response.is_a?(::Curl::Easy)
+    assert response.body_str == "Hello TraceView!"
+    assert response.response_code == 200
+    assert response.header_str =~ /X-Trace/, "X-Trace response header"
 
     traces = get_all_traces
-    assert_equal traces.count, 7
+    assert_equal 7,                         traces.count, "Trace count"
     validate_outer_layers(traces, "curb_tests")
-    valid_edges?(traces)
 
-    assert_equal traces[1]['IsService'], 1
-    assert_equal traces[1]['RemoteURL'], "http://127.0.0.1:8101/"
-    # FIXME
-    # assert_equal traces[1]['HTTPMethod'], 'POST'
-    assert traces[1].key?('Backtrace')
+    assert_equal 'curb',                    traces[1]['Layer']
+    assert_equal 'entry',                   traces[1]['Label']
+    assert_equal 1,                         traces[1]['IsService']
+    assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
+    assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
+    assert       traces[1].key?('Backtrace')
 
-    assert_equal traces[5]['Layer'], 'curb'
-    assert_equal traces[5]['Label'], 'exit'
-    assert_equal traces[5]['HTTPStatus'], 200
+    assert_equal 'curb',                    traces[5]['Layer']
+    assert_equal 'exit',                    traces[5]['Label']
+    assert_equal 200,                       traces[5]['HTTPStatus']
+  end
+
+  def test_easy_http_head
+    clear_all_traces
+
+    c = nil
+
+    TraceView::API.start_trace('curb_tests') do
+      c = Curl::Easy.new("http://127.0.0.1:8101/")
+      c.http_head
+    end
+
+    assert c.is_a?(::Curl::Easy), "Response type"
+    assert c.response_code == 200
+    assert c.header_str =~ /X-Trace/, "X-Trace response header"
+
+    traces = get_all_traces
+    assert_equal 7, traces.count, "Trace count"
+    validate_outer_layers(traces, "curb_tests")
+
+    assert_equal 'curb',                    traces[1]['Layer']
+    assert_equal 'entry',                   traces[1]['Label']
+    assert_equal 1,                         traces[1]['IsService']
+    assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
+    assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
+    assert       traces[1].key?('Backtrace')
+
+    assert_equal 'curb',                    traces[5]['Layer']
+    assert_equal 'exit',                    traces[5]['Label']
+    assert_equal 200,                       traces[5]['HTTPStatus']
   end
 
   def test_class_fetch_with_block
@@ -104,55 +172,121 @@ class CurbTest < Minitest::Test
 
     TraceView::API.start_trace('curb_tests') do
       response = Curl::Easy.perform("http://127.0.0.1:8101/") do |curl|
-        curl.headers["User-Agent"] = "myapp-0.0"
-        curl.verbose = true
+        curl.headers["User-Agent"] = "TraceView 2000"
       end
     end
 
-    xtrace = response.headers['X-Trace']
-    assert xtrace
-    assert TraceView::XTrace.valid?(xtrace)
+    assert response.is_a?(::Curl::Easy), "Response type"
+    assert response.response_code == 200
+    assert response.header_str =~ /X-Trace/, "X-Trace response header"
 
     traces = get_all_traces
-    assert_equal traces.count, 7
+    assert_equal 7, traces.count, "Trace count"
     validate_outer_layers(traces, "curb_tests")
-    valid_edges?(traces)
 
-    assert_equal traces[1]['IsService'], 1
-    assert_equal traces[1]['RemoteURL'], "http://127.0.0.1:8101/"
-    # FIXME
-    # assert_equal traces[1]['HTTPMethod'], 'POST'
+    assert_equal 'curb',                    traces[1]['Layer']
+    assert_equal 'entry',                   traces[1]['Label']
+    assert_equal traces[5]['Label'], 'exit'
+    assert_equal 1,                         traces[1]['IsService']
+    assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
+    assert_equal 'GET',                     traces[1]['HTTPMethod']
     assert traces[1].key?('Backtrace')
 
-    assert_equal traces[5]['Layer'], 'curb'
-    assert_equal traces[5]['Label'], 'exit'
-    assert_equal traces[5]['HTTPStatus'], 200
+    assert_equal 'curb',                    traces[5]['Layer']
+    assert_equal 'exit',                    traces[5]['Label']
+    assert_equal 200,                       traces[5]['HTTPStatus']
   end
 
   def test_cross_app_tracing
     clear_all_traces
 
+    @cross_host = TraceView::Config[:curb][:cross_host]
+    TraceView::Config[:curb][:cross_host] = true
+
     response = nil
 
     TraceView::API.start_trace('curb_tests') do
-      response = ::Curl.get('http://127.0.0.1:8101/?blah=1')
+      response = ::Curl.get('http://127.0.0.1:8101/?curb_cross_host=1')
     end
 
     xtrace = response.headers['X-Trace']
-    assert xtrace
+    assert xtrace, "X-Trace response header"
     assert TraceView::XTrace.valid?(xtrace)
+    assert response.header_str =~ /X-Trace/, "X-Trace response header"
 
     traces = get_all_traces
-    assert_equal traces.count, 7
+    assert_equal 7, traces.count, "Trace count"
     validate_outer_layers(traces, "curb_tests")
-    valid_edges?(traces)
+    assert valid_edges?(traces), "Trace edge validation"
 
-    assert_equal traces[1]['IsService'], 1
-    assert_equal traces[1]['RemoteURL'], "http://127.0.0.1:8101/?blah=1&"
-    # FIXME
-    # assert_equal traces[1]['HTTPMethod'], 'GET'
-    assert traces[1].key?('Backtrace')
-    assert_equal traces[5]['HTTPStatus'], 200
+    assert_equal 'curb',                    traces[1]['Layer']
+    assert_equal 'entry',                   traces[1]['Label']
+    assert_equal 1,                         traces[1]['IsService']
+    assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
+    assert_equal "http://127.0.0.1:8101/?curb_cross_host=1&",  traces[1]['RemoteURL']
+    assert       traces[1].key?('Backtrace')
+
+    assert_equal 'curb',                    traces[5]['Layer']
+    assert_equal 'exit',                    traces[5]['Label']
+    assert_equal 200,                       traces[5]['HTTPStatus']
+
+    TraceView::Config[:curb][:cross_host] = @cross_host
+  end
+
+  def test_multi_basic
+    clear_all_traces
+
+    responses = nil
+    easy_options = {:follow_location => true}
+    multi_options = {:pipeline => false}
+
+    urls = []
+    urls << "http://127.0.0.1:8101/?one=1"
+    urls << "http://127.0.0.1:8101/?two=2"
+    urls << "http://127.0.0.1:8101/?three=3"
+
+    TraceView::API.start_trace('curb_tests') do
+      responses = Curl::Multi.get(urls, easy_options, multi_options) do |easy|
+        nil
+      end
+    end
+
+    traces = get_all_traces
+    assert_equal 13, traces.count, "Trace count"
+    validate_outer_layers(traces, "curb_tests")
+
+    assert_equal traces[1]['Layer'], 'curb_multi'
+    assert_equal traces[1]['Label'], 'entry'
+    assert_equal traces[11]['Layer'], 'curb_multi'
+    assert_equal traces[11]['Label'], 'exit'
+  end
+
+  def test_multi_basic_pipeline
+    clear_all_traces
+
+    responses = nil
+    easy_options = {:follow_location => true}
+    multi_options = {:pipeline => true}
+
+    urls = []
+    urls << "http://127.0.0.1:8101/?one=1"
+    urls << "http://127.0.0.1:8101/?two=2"
+    urls << "http://127.0.0.1:8101/?three=3"
+
+    TraceView::API.start_trace('curb_tests') do
+      responses = Curl::Multi.get(urls, easy_options, multi_options) do |easy|
+        nil
+      end
+    end
+
+    traces = get_all_traces
+    assert_equal 13, traces.count, "Trace count"
+    validate_outer_layers(traces, "curb_tests")
+
+    assert_equal traces[1]['Layer'], 'curb_multi'
+    assert_equal traces[1]['Label'], 'entry'
+    assert_equal traces[11]['Layer'], 'curb_multi'
+    assert_equal traces[11]['Label'], 'exit'
   end
 
   def test_requests_with_errors
@@ -166,24 +300,23 @@ class CurbTest < Minitest::Test
     end
 
     traces = get_all_traces
-    assert_equal traces.count, 5
+    assert_equal 5, traces.count, "Trace count"
     validate_outer_layers(traces, "curb_tests")
-    valid_edges?(traces)
+    assert valid_edges?(traces), "Trace edge validation"
 
-    assert_equal traces[1]['IsService'], 1
-    assert_equal traces[1]['RemoteURL'], 'http://asfjalkfjlajfljkaljf/'
-    # FIXME
-    # assert_equal traces[1]['HTTPMethod'], 'GET'
+    assert_equal 1,                                traces[1]['IsService']
+    assert_equal 'http://asfjalkfjlajfljkaljf/',   traces[1]['RemoteURL']
+    assert_equal 'GET',                            traces[1]['HTTPMethod']
     assert traces[1].key?('Backtrace')
 
-    assert_equal traces[2]['Layer'], 'curb'
-    assert_equal traces[2]['Label'], 'error'
-    assert_equal traces[2]['ErrorClass'], "Curl::Err::HostResolutionError"
+    assert_equal 'curb',                           traces[2]['Layer']
+    assert_equal 'error',                          traces[2]['Label']
+    assert_equal "Curl::Err::HostResolutionError", traces[2]['ErrorClass']
     assert traces[2].key?('ErrorMsg')
     assert traces[2].key?('Backtrace')
 
-    assert_equal traces[3]['Layer'], 'curb'
-    assert_equal traces[3]['Label'], 'exit'
+    assert_equal 'curb',                           traces[3]['Layer']
+    assert_equal 'exit',                           traces[3]['Label']
   end
 
   def test_obey_log_args_when_false
@@ -198,11 +331,9 @@ class CurbTest < Minitest::Test
       http = Curl.get('http://127.0.0.1:8101/?blah=1')
     end
 
-    assert http.headers['X-Trace'] != nil
-
     traces = get_all_traces
-    assert_equal traces.count, 7
-    assert_equal traces[1]['RemoteURL'], "http://127.0.0.1:8101/"
+    assert_equal 7, traces.count, "Trace count"
+    assert_equal "http://127.0.0.1:8101/",         traces[1]['RemoteURL']
 
     TraceView::Config[:curb][:log_args] = @log_args
   end
@@ -219,33 +350,83 @@ class CurbTest < Minitest::Test
       http = ::Curl.get('http://127.0.0.1:8101/?blah=1')
     end
 
-    assert http.headers['X-Trace'] != nil
-
     traces = get_all_traces
-    assert_equal traces.count, 7
-    assert_equal traces[1]['RemoteURL'], "http://127.0.0.1:8101/?blah=1&"
+    assert_equal 7, traces.count, "Trace count"
+    assert_equal "http://127.0.0.1:8101/?blah=1&", traces[1]['RemoteURL']
 
     TraceView::Config[:curb][:log_args] = @log_args
   end
 
-  def test_without_tracing
+  def test_without_tracing_class_get
     clear_all_traces
 
     @tm = TraceView::Config[:tracing_mode]
     TraceView::Config[:tracing_mode] = :never
 
-    http = nil
+    response = nil
 
     TraceView::API.start_trace('httpclient_tests') do
-      http = ::Curl.get('http://127.0.0.1:8101/?blah=1')
+      response = ::Curl.get('http://127.0.0.1:8101/?blah=1')
     end
 
-    assert http.headers['X-Trace'] == nil
+    assert response.headers['X-Trace'] == nil
+    assert response.body_str == "Hello TraceView!"
+    assert response.response_code == 200
 
     traces = get_all_traces
-    assert_equal traces.count, 0
+    assert_equal 0, traces.count, "Trace count"
 
     TraceView::Config[:tracing_mode] = @tm
+  end
+
+  def test_without_tracing_easy_perform
+    clear_all_traces
+
+    @tm = TraceView::Config[:tracing_mode]
+    TraceView::Config[:tracing_mode] = :never
+
+    response = nil
+
+    TraceView::API.start_trace('curb_tests') do
+      response = Curl::Easy.perform("http://127.0.0.1:8101/")
+    end
+
+    assert response.headers['X-Trace'] == nil
+    assert response.body_str == "Hello TraceView!"
+    assert response.response_code == 200
+
+    traces = get_all_traces
+    assert_equal 0, traces.count, "Trace count"
+
+    TraceView::Config[:tracing_mode] = @tm
+  end
+
+  def test_obey_collect_backtraces_when_true
+    @cb = TraceView::Config[:curb][:collect_backtraces]
+    TraceView::Config[:curb][:collect_backtraces] = true
+
+    TraceView::API.start_trace('curb_test') do
+      Curl.get("http://127.0.0.1:8101/")
+    end
+
+    traces = get_all_traces
+    layer_has_key(traces, 'curb', 'Backtrace')
+
+    TraceView::Config[:curb][:collect_backtraces] = @cb
+  end
+
+  def test_obey_collect_backtraces_when_false
+    @cb = TraceView::Config[:curb][:collect_backtraces]
+    TraceView::Config[:curb][:collect_backtraces] = false
+
+    TraceView::API.start_trace('curb_test') do
+      Curl.get("http://127.0.0.1:8101/")
+    end
+
+    traces = get_all_traces
+    layer_doesnt_have_key(traces, 'curb', 'Backtrace')
+
+    TraceView::Config[:curb][:collect_backtraces] = @cb
   end
 end
 

--- a/test/instrumentation/curb_test.rb
+++ b/test/instrumentation/curb_test.rb
@@ -56,14 +56,13 @@ if RUBY_VERSION > '1.8.7'
 
       assert_equal 'curb',                    traces[1]['Layer']
       assert_equal 'entry',                   traces[1]['Label']
-      assert_equal 1,                         traces[1]['IsService']
-      assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
-      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-      assert       traces[1].key?('Backtrace')
+      assert_equal false,                     traces[1].key?('IsService')
+      assert_equal false,                     traces[1].key?('RemoteURL')
+      assert_equal false,                     traces[1].key?('HTTPMethod')
+      assert traces[1].key?('Backtrace')
 
       assert_equal 'curb',                    traces[5]['Layer']
       assert_equal 'exit',                    traces[5]['Label']
-      assert_equal 200,                       traces[5]['HTTPStatus']
     end
 
     def test_class_delete_request
@@ -83,14 +82,13 @@ if RUBY_VERSION > '1.8.7'
 
       assert_equal 'curb',                    traces[1]['Layer']
       assert_equal 'entry',                   traces[1]['Label']
-      assert_equal 1,                         traces[1]['IsService']
-      assert_equal 'DELETE',                  traces[1]['HTTPMethod'], "HTTP Method"
-      assert_equal "http://127.0.0.1:8101/?curb_delete_test",  traces[1]['RemoteURL']
-      assert       traces[1].key?('Backtrace')
+      assert_equal false,                     traces[1].key?('IsService')
+      assert_equal false,                     traces[1].key?('RemoteURL')
+      assert_equal false,                     traces[1].key?('HTTPMethod')
+      assert traces[1].key?('Backtrace')
 
       assert_equal 'curb',                    traces[5]['Layer']
       assert_equal 'exit',                    traces[5]['Label']
-      assert_equal 200,                       traces[5]['HTTPStatus']
     end
 
     def test_class_post_request
@@ -110,14 +108,13 @@ if RUBY_VERSION > '1.8.7'
 
       assert_equal 'curb',                    traces[1]['Layer']
       assert_equal 'entry',                   traces[1]['Label']
-      assert_equal 1,                         traces[1]['IsService']
-      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-      assert_equal 'POST',                    traces[1]['HTTPMethod'], "HTTP Method"
-      assert       traces[1].key?('Backtrace')
+      assert_equal false,                     traces[1].key?('IsService')
+      assert_equal false,                     traces[1].key?('RemoteURL')
+      assert_equal false,                     traces[1].key?('HTTPMethod')
+      assert traces[1].key?('Backtrace')
 
       assert_equal 'curb',                    traces[5]['Layer']
       assert_equal 'exit',                    traces[5]['Label']
-      assert_equal 200,                       traces[5]['HTTPStatus']
     end
 
     def test_easy_class_perform
@@ -138,14 +135,13 @@ if RUBY_VERSION > '1.8.7'
 
       assert_equal 'curb',                    traces[1]['Layer']
       assert_equal 'entry',                   traces[1]['Label']
-      assert_equal 1,                         traces[1]['IsService']
-      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-      assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
-      assert       traces[1].key?('Backtrace')
+      assert_equal false,                     traces[1].key?('IsService')
+      assert_equal false,                     traces[1].key?('RemoteURL')
+      assert_equal false,                     traces[1].key?('HTTPMethod')
+      assert traces[1].key?('Backtrace')
 
       assert_equal 'curb',                    traces[5]['Layer']
       assert_equal 'exit',                    traces[5]['Label']
-      assert_equal 200,                       traces[5]['HTTPStatus']
     end
 
     def test_easy_http_head
@@ -166,14 +162,13 @@ if RUBY_VERSION > '1.8.7'
 
       assert_equal 'curb',                    traces[1]['Layer']
       assert_equal 'entry',                   traces[1]['Label']
-      assert_equal 1,                         traces[1]['IsService']
-      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-      assert_equal 'GET',                     traces[1]['HTTPMethod'], "HTTP Method"
-      assert       traces[1].key?('Backtrace')
+      assert_equal false,                     traces[1].key?('IsService')
+      assert_equal false,                     traces[1].key?('RemoteURL')
+      assert_equal false,                     traces[1].key?('HTTPMethod')
+      assert traces[1].key?('Backtrace')
 
       assert_equal 'curb',                    traces[5]['Layer']
       assert_equal 'exit',                    traces[5]['Label']
-      assert_equal 200,                       traces[5]['HTTPStatus']
     end
 
     def test_easy_http_put
@@ -194,14 +189,13 @@ if RUBY_VERSION > '1.8.7'
 
       assert_equal 'curb',                    traces[1]['Layer']
       assert_equal 'entry',                   traces[1]['Label']
-      assert_equal 1,                         traces[1]['IsService']
-      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-      assert_equal 'PUT',                     traces[1]['HTTPMethod'], "HTTP Method"
-      assert       traces[1].key?('Backtrace')
+      assert_equal false,                     traces[1].key?('IsService')
+      assert_equal false,                     traces[1].key?('RemoteURL')
+      assert_equal false,                     traces[1].key?('HTTPMethod')
+      assert traces[1].key?('Backtrace')
 
       assert_equal 'curb',                    traces[5]['Layer']
       assert_equal 'exit',                    traces[5]['Label']
-      assert_equal 200,                       traces[5]['HTTPStatus']
     end
 
     def test_easy_http_post
@@ -223,14 +217,13 @@ if RUBY_VERSION > '1.8.7'
 
       assert_equal 'curb',                    traces[1]['Layer']
       assert_equal 'entry',                   traces[1]['Label']
-      assert_equal 1,                         traces[1]['IsService']
-      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-      assert_equal 'POST',                    traces[1]['HTTPMethod'], "HTTP Method"
-      assert       traces[1].key?('Backtrace')
+      assert_equal false,                     traces[1].key?('IsService')
+      assert_equal false,                     traces[1].key?('RemoteURL')
+      assert_equal false,                     traces[1].key?('HTTPMethod')
+      assert traces[1].key?('Backtrace')
 
       assert_equal 'curb',                    traces[5]['Layer']
       assert_equal 'exit',                    traces[5]['Label']
-      assert_equal 200,                       traces[5]['HTTPStatus']
     end
 
     def test_class_fetch_with_block
@@ -253,14 +246,14 @@ if RUBY_VERSION > '1.8.7'
       assert_equal 'curb',                    traces[1]['Layer']
       assert_equal 'entry',                   traces[1]['Label']
       assert_equal traces[5]['Label'], 'exit'
-      assert_equal 1,                         traces[1]['IsService']
-      assert_equal "http://127.0.0.1:8101/",  traces[1]['RemoteURL']
-      assert_equal 'GET',                     traces[1]['HTTPMethod']
+      assert_equal false,                     traces[1].key?('IsService')
+      assert_equal false,                     traces[1].key?('RemoteURL')
+      assert_equal false,                     traces[1].key?('HTTPMethod')
       assert traces[1].key?('Backtrace')
 
       assert_equal 'curb',                    traces[5]['Layer']
       assert_equal 'exit',                    traces[5]['Label']
-      assert_equal 200,                       traces[5]['HTTPStatus']
+      assert_equal false,                     traces[5].key?('HTTPStatus')
     end
 
     def test_cross_app_tracing
@@ -423,9 +416,9 @@ if RUBY_VERSION > '1.8.7'
       validate_outer_layers(traces, "curb_tests")
       assert valid_edges?(traces), "Trace edge validation"
 
-      assert_equal 1,                                traces[1]['IsService']
-      assert_equal 'http://asfjalkfjlajfljkaljf/',   traces[1]['RemoteURL']
-      assert_equal 'GET',                            traces[1]['HTTPMethod']
+      assert_equal false,                     traces[1].key?('IsService')
+      assert_equal false,                     traces[1].key?('RemoteURL')
+      assert_equal false,                     traces[1].key?('HTTPMethod')
       assert traces[1].key?('Backtrace')
 
       assert_equal 'curb',                           traces[2]['Layer']
@@ -443,6 +436,7 @@ if RUBY_VERSION > '1.8.7'
       # semaphore to lock between other running tests.
       TraceView.config_lock.synchronize {
         TraceView::Config[:curb][:log_args] = false
+        TraceView::Config[:curb][:cross_host] = true
 
         http = nil
 
@@ -461,6 +455,7 @@ if RUBY_VERSION > '1.8.7'
       # semaphore to lock between other running tests.
       TraceView.config_lock.synchronize {
         TraceView::Config[:curb][:log_args] = true
+        TraceView::Config[:curb][:cross_host] = true
 
         http = nil
 

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -30,12 +30,13 @@ describe "TraceView::Config" do
     instrumentation = TraceView::Config.instrumentation
 
     # Verify the number of individual instrumentations
-    instrumentation.count.must_equal 21
+    instrumentation.count.must_equal 22
 
     TraceView::Config[:action_controller][:enabled].must_equal true
     TraceView::Config[:action_view][:enabled].must_equal true
     TraceView::Config[:active_record][:enabled].must_equal true
     TraceView::Config[:cassandra][:enabled].must_equal true
+    TraceView::Config[:curb][:enabled].must_equal true
     TraceView::Config[:dalli][:enabled].must_equal true
     TraceView::Config[:em_http_request][:enabled].must_equal false
     TraceView::Config[:excon][:enabled].must_equal true
@@ -58,6 +59,7 @@ describe "TraceView::Config" do
     TraceView::Config[:action_view][:log_args].must_equal true
     TraceView::Config[:active_record][:log_args].must_equal true
     TraceView::Config[:cassandra][:log_args].must_equal true
+    TraceView::Config[:curb][:log_args].must_equal true
     TraceView::Config[:dalli][:log_args].must_equal true
     TraceView::Config[:em_http_request][:log_args].must_equal true
     TraceView::Config[:excon][:log_args].must_equal true


### PR DESCRIPTION
Let's provide some performance instrumentation on this HTTP client: https://github.com/taf2/curb

- [x] Add `:curb` to `TV::Config`
- [x] Report curb in `__Init` and add tests to validate
- [x] Instrument and add tests for `Curl::Easy`
- [x] Instrument and add tests for `Curl::Multi`
- [x] Instrument and add tests for `http_[put|post|head|delete]`
- [x] Report and add tests of curb generated errors
- [x] Support and test config params (`:log_args` and `:backtrace collection`)
- [x] Add config param to optionally handle cross host tracing (due to libcurl inst)
- [x] Support and tests for optional cross app host tracing (via `TV::Config[:curb][:cross_host]`)
- [x] URL blacklisting
- [x] Add tests to validate functionality when NOT tracing
- [x] Test against advanced Multi client usage
- [x] ~~Fix Ruby 1.8 test failures related to tracelyzer~~
- [x] Cleanup, re-review code & refactor
- [x] Generate manual traces in test stacks
- [x] Backtest to verify version support ( >= 0.8.6)
- [x] Document new config options (`:cross_host`)
- [ ] Add to support matrix

Remaining items to be fixed:
- [x] Don't send any service keys if `TV::Config[:curb][:cross_host]` isn't set
- [x] Identify and fix broken traces in combo with libcurl instrumentation