### PR TITLE
Fix URL query params config

### DIFF
--- a/lib/traceview/config.rb
+++ b/lib/traceview/config.rb
@@ -18,7 +18,7 @@ module TraceView
                          :typhoeus]
 
     # Subgrouping of instrumentation
-    @@http_clients = [:curb, :excon, :faraday, :httpclient, :nethttp, :rest_client, :typhoeus]
+    @@http_clients = [:curb, :excon, :em_http_request, :faraday, :httpclient, :nethttp, :rest_client, :typhoeus]
 
     ##
     # Return the raw nested hash.
@@ -217,14 +217,14 @@ module TraceView
       elsif key == :include_url_query_params
         # Obey the global flag and update all of the per instrumentation
         # <tt>:log_args</tt> values.
-        @@http_clients.each do |i|
-          @@config[i][:log_args] = value
-        end
+        @@config[:rack][:log_args] = value
 
       elsif key == :include_remote_url_params
         # Obey the global flag and update all of the per instrumentation
         # <tt>:log_args</tt> values.
-        @@config[:rack][:log_args] = value
+        @@http_clients.each do |i|
+          @@config[i][:log_args] = value
+        end
       end
 
       # Update liboboe if updating :tracing_mode

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -99,31 +99,31 @@ describe "TraceView::Config" do
     # equivalents should follow suit.
 
     #
-    # :include_url_query_params
+    # :include_remote_url_params
     #
 
     # Check defaults
-    TraceView::Config[:include_url_query_params].must_equal true
+    TraceView::Config[:include_remote_url_params].must_equal true
     http_clients.each do |i|
       TraceView::Config[i][:log_args].must_equal true
     end
 
     # Check obedience
-    TraceView::Config[:include_url_query_params] = false
+    TraceView::Config[:include_remote_url_params] = false
     http_clients.each do |i|
       TraceView::Config[i][:log_args].must_equal false
     end
 
     #
-    # :include_remote_url_params
+    # :include_url_query_params
     #
 
     # Check default
-    TraceView::Config[:include_remote_url_params].must_equal true
+    TraceView::Config[:include_url_query_params].must_equal true
     TraceView::Config[:rack][:log_args].must_equal true
 
     # Check obedience
-    TraceView::Config[:include_remote_url_params] = false
+    TraceView::Config[:include_url_query_params] = false
     TraceView::Config[:rack][:log_args].must_equal false
 
     # Restore the previous values


### PR DESCRIPTION
The core config uses per instrumentation `:log_args`, but setting `:include_url_query_params` incorrectly sets the `:log_args` for HTTP clients.